### PR TITLE
Fix nftbk github issue 20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ run-cli:
 run-cli-test:
 	cargo run --bin nftbk-cli -- --tokens-config-path config_tokens_test.toml --output-path nft_backup_test $(filter-out $@,$(MAKECMDGOALS))
 
+.PHONY: run-cli-server-test
+run-cli-server-test:
+	cargo run --bin nftbk-cli -- --tokens-config-path config_tokens_test.toml --output-path nft_backup_test --server-mode true $(filter-out $@,$(MAKECMDGOALS))
+
 .PHONY: run
 run: start-db run-server
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -19,6 +19,7 @@ use nftbk::logging;
 use nftbk::logging::LogLevel;
 use nftbk::server::api::{BackupRequest, BackupResponse, StatusResponse, Tokens};
 use nftbk::server::archive::archive_format_from_user_agent;
+use nftbk::ProcessManagementConfig;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -380,7 +381,10 @@ async fn main() -> Result<()> {
         token_config,
         output_path: output_path.clone(),
         prune_redundant: args.prune_redundant,
-        exit_on_error: args.exit_on_error,
+        process_config: ProcessManagementConfig {
+            exit_on_error: args.exit_on_error,
+            shutdown_flag: None,
+        },
     };
     let (_files, error_log) = backup_from_config(backup_config, None).await?;
     // Write error log to file if present

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tokio::fs;
 use tokio::sync::mpsc;
@@ -37,6 +38,7 @@ pub struct AppState {
     pub download_tokens: Arc<Mutex<HashMap<String, (String, u64)>>>,
     pub backup_job_sender: mpsc::Sender<BackupJobOrShutdown>,
     pub db: Arc<Db>,
+    pub shutdown_flag: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Clone)]
@@ -72,6 +74,7 @@ impl AppState {
         backup_job_sender: mpsc::Sender<BackupJobOrShutdown>,
         db_url: &str,
         max_connections: u32,
+        shutdown_flag: Arc<AtomicBool>,
     ) -> Self {
         let config_content = tokio::fs::read_to_string(chain_config_path)
             .await
@@ -93,6 +96,7 @@ impl AppState {
             download_tokens: Arc::new(Mutex::new(HashMap::new())),
             backup_job_sender,
             db,
+            shutdown_flag,
         }
     }
 }

--- a/src/server/pruner.rs
+++ b/src/server/pruner.rs
@@ -11,9 +11,9 @@ pub async fn run_pruner(
     db: Arc<Db>,
     base_dir: String,
     interval_seconds: u64,
-    running: Arc<AtomicBool>,
+    shutdown_flag: Arc<AtomicBool>,
 ) {
-    while running.load(Ordering::SeqCst) {
+    while !shutdown_flag.load(Ordering::SeqCst) {
         info!("Running pruning process...");
         match db.list_expired_backups().await {
             Ok(expired) => {
@@ -48,7 +48,7 @@ pub async fn run_pruner(
         info!("Pruning process completed");
         let mut slept = 0;
         let sleep_step = 1;
-        while slept < interval_seconds && running.load(Ordering::SeqCst) {
+        while slept < interval_seconds && !shutdown_flag.load(Ordering::SeqCst) {
             sleep(TokioDuration::from_secs(sleep_step)).await;
             slept += sleep_step;
         }


### PR DESCRIPTION
Implement graceful shutdown for backup operations to allow clean termination of long-running jobs.

This PR addresses issue #20 by extending graceful shutdown capabilities to the core backup library, NFT processing, and archiving functions. An `Arc<AtomicBool>` flag is used to signal shutdown, allowing operations to be interrupted safely at various critical points.

---

[Open in Web](https://www.cursor.com/agents?id=bc-3ff45955-c8ff-4282-8a3c-14a94905c959) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3ff45955-c8ff-4282-8a3c-14a94905c959)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)