### PR TITLE
feat: add support for dynamic pricing in x402 middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru",
+ "lru 0.13.0",
  "parking_lot",
  "pin-project",
  "reqwest 0.12.24",
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
+checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1824,9 +1824,9 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1945,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
+checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
 dependencies = [
  "brotli",
  "compression-core",
@@ -1957,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+checksum = "3a9b614a5787ef0c8802a55766480563cb3a93b435898c422ed2a359cf811582"
 
 [[package]]
 name = "concurrent-queue"
@@ -4262,6 +4262,15 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
@@ -4457,9 +4466,9 @@ dependencies = [
  "futures-util",
  "hex",
  "httpdate",
- "hyper 1.7.0",
  "josekit",
  "libc",
+ "lru 0.12.5",
  "p256",
  "pkcs8",
  "prettytable",
@@ -4770,9 +4779,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.74"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -4802,9 +4811,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.110"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -5475,9 +5484,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -11103,9 +11112,9 @@ dependencies = [
 
 [[package]]
 name = "x402-axum"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99320795584c2a5fe4fed86bdaf59a2a83338082ecdaa6bc631775938a1a4c01"
+checksum = "ed6dc5e0ffa1a47c6a013da7c94cfbe82f1f71182130bca3305f57c66140ecf9"
 dependencies = [
  "axum-core",
  "http 1.3.1",
@@ -11121,9 +11130,9 @@ dependencies = [
 
 [[package]]
 name = "x402-rs"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544d67133b2a56cd64623665958d21d7b75167984520654188d31f02af71df1d"
+checksum = "5da32ef9625883be2175f8bc194fcf3e84712dc2f54e8de78fd015a02b02ed3d"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ futures = "0.3"
 futures-util = "0.3"
 hex = "0.4.3"
 httpdate = "1.0"
-hyper = { version = "1.0", features = ["full"] }
 josekit = "0.10.3"
 libc = "0.2"
+lru = "0.12"
 prettytable = "0.10"
 rand = "0.8"
 regex = "1"
@@ -66,9 +66,8 @@ urlencoding = "2.1"
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
 uuid = { version = "1.4", features = ["v4"] }
-# x402-axum = { git = "https://github.com/0xmichalis/x402-rs", branch = "main", package = "x402-axum" }
-x402-axum = { version = "0.6.1" }
-x402-rs = { version = "0.9.1" }
+x402-axum = { version = "0.6.2" }
+x402-rs = { version = "0.9.3" }
 zip = "0.6"
 
 [dev-dependencies]

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -60,6 +60,17 @@ struct Args {
     /// Disable colored log output. NO_COLOR and FORCE_COLOR environment variables take precedence.
     #[arg(long, default_value_t = false, action = clap::ArgAction::Set)]
     no_color: bool,
+
+    /// Maximum number of quotes to cache in memory for dynamic pricing.
+    /// When the cache is full, the least recently used quotes are evicted.
+    /// This cache stores quote IDs (UUID string, ~36 bytes) and their associated data
+    /// (price string ~10 bytes + task_id SHA256 hex string ~64 bytes) for x402 dynamic pricing.
+    /// Each entry uses approximately ~220 bytes including overhead, so:
+    /// - 100 entries ≈ 22 KB
+    /// - 1000 entries ≈ 220 KB (default)
+    /// - 10000 entries ≈ 2.2 MB
+    #[arg(long, default_value_t = 1000)]
+    quote_cache_size: usize,
 }
 
 #[tokio::main]
@@ -112,6 +123,7 @@ async fn main() {
         jwt_credentials,
         x402_config,
         ipfs_pinning_configs,
+        quote_cache_size: args.quote_cache_size,
     };
 
     if let Err(e) = run_server(config).await {

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -38,6 +38,24 @@ pub struct BackupCreateResponse {
     pub task_id: String,
 }
 
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct QuoteCreateResponse {
+    /// Unique identifier for the quote
+    #[schema(example = "550e8400-e29b-41d4-a716-446655440000")]
+    pub quote_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct QuoteResponse {
+    /// Unique identifier for the quote
+    #[schema(example = "550e8400-e29b-41d4-a716-446655440000")]
+    pub quote_id: String,
+    /// Price in USDC (human-readable format, e.g., "0.1")
+    /// None if the quote is still being computed
+    #[schema(example = "0.1")]
+    pub price: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
 pub struct SubresourceStatus {
     /// Subresource status

--- a/src/server/handlers/handle_archive_download.rs
+++ b/src/server/handlers/handle_archive_download.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use axum::response::Response;
 use axum::Json;
 use axum::{
@@ -9,7 +11,6 @@ use axum::{
 use base64::Engine;
 use rand::rngs::OsRng;
 use rand::RngCore;
-use std::path::PathBuf;
 use tokio::fs::File;
 use tokio_util::io::ReaderStream;
 
@@ -263,6 +264,7 @@ mod handle_download_tests {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
     use std::collections::HashMap;
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
     use tokio::sync::{mpsc, Mutex};
 
@@ -289,11 +291,15 @@ mod handle_download_tests {
             auth_token: None,
             pruner_retention_days: 7,
             download_tokens: Arc::new(Mutex::new(HashMap::new())),
+            quote_cache: Arc::new(Mutex::new(lru::LruCache::new(
+                NonZeroUsize::new(1000).unwrap(),
+            ))),
             backup_task_sender: mpsc::channel(1).0,
             db,
             shutdown_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             ipfs_pinning_configs: Vec::new(),
             ipfs_pinning_instances: Arc::new(Vec::new()),
+            x402_config: None,
         }
     }
 

--- a/src/server/handlers/handle_backup_quote.rs
+++ b/src/server/handlers/handle_backup_quote.rs
@@ -1,0 +1,388 @@
+use axum::{
+    extract::{Extension, Json, Path, State},
+    http::{header, HeaderMap, StatusCode},
+    response::IntoResponse,
+};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::server::api::{
+    ApiProblem, BackupRequest, ProblemJson, QuoteCreateResponse, QuoteResponse,
+};
+use crate::server::hashing::compute_task_id;
+use crate::server::AppState;
+
+/// Request a quote for creating a backup. Returns a quote_id that can be used to retrieve the quote
+/// via GET /v1/backups/quote/{quote_id} once it's ready.
+#[utoipa::path(
+    post,
+    path = "/v1/backups/quote",
+    request_body = BackupRequest,
+    responses(
+        (status = 202, description = "Quote request accepted", body = QuoteCreateResponse),
+        (status = 400, description = "Invalid request", body = ApiProblem, content_type = "application/problem+json"),
+        (status = 500, description = "Internal server error", body = ApiProblem, content_type = "application/problem+json"),
+    ),
+    tag = "backups",
+    security(("bearer_auth" = []))
+)]
+pub async fn handle_backup_quote(
+    State(state): State<AppState>,
+    Extension(_requestor): Extension<Option<String>>,
+    Json(req): Json<BackupRequest>,
+) -> axum::response::Response {
+    // Validate the request (same validation as backup creation)
+    if let Err(msg) =
+        crate::server::handlers::handle_backup_create::validate_backup_request(&state, &req)
+    {
+        let problem = ProblemJson::from_status(
+            StatusCode::BAD_REQUEST,
+            Some(msg),
+            Some("/v1/backups/quote".to_string()),
+        );
+        return problem.into_response();
+    }
+
+    // Generate a unique quote ID
+    let quote_id = Uuid::new_v4().to_string();
+
+    // Compute the task_id for this request (same as backup creation)
+    let requestor_str = _requestor.as_deref().unwrap_or("");
+    let task_id = compute_task_id(&req.tokens, Some(requestor_str));
+
+    // Store the quote in the cache with None price (pending) and task_id for validation
+    {
+        let mut cache = state.quote_cache.lock().await;
+        cache.put(quote_id.clone(), (None, task_id));
+    }
+
+    // Get price from x402 config if available, otherwise return error
+    // TODO: Implement actual price computation asynchronously.
+    let price = if let Some(cfg) = state.x402_config.as_ref() {
+        cfg.price.clone()
+    } else {
+        let problem = ProblemJson::from_status(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Some("x402 configuration not available".to_string()),
+            Some("/v1/backups/quote".to_string()),
+        );
+        return problem.into_response();
+    };
+    {
+        let mut cache = state.quote_cache.lock().await;
+        if let Some((cached_price, _task_id)) = cache.get_mut(&quote_id) {
+            *cached_price = Some(price.clone());
+        }
+    }
+
+    info!("Created quote {} with price {}", quote_id, price);
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::LOCATION,
+        format!("/v1/backups/quote/{}", quote_id).parse().unwrap(),
+    );
+
+    (
+        StatusCode::ACCEPTED,
+        headers,
+        Json(QuoteCreateResponse { quote_id }),
+    )
+        .into_response()
+}
+
+/// Get a quote by quote_id. Returns the quote with price if ready, or 202 Accepted if still being computed.
+#[utoipa::path(
+    get,
+    path = "/v1/backups/quote/{quote_id}",
+    params(
+        ("quote_id" = String, Path, description = "Unique identifier for the quote")
+    ),
+    responses(
+        (status = 200, description = "Quote retrieved successfully with price", body = QuoteResponse),
+        (status = 202, description = "Quote request is still being processed", body = QuoteResponse),
+        (status = 404, description = "Quote not found", body = ApiProblem, content_type = "application/problem+json"),
+    ),
+    tag = "backups",
+    security(("bearer_auth" = []))
+)]
+pub async fn handle_backup_quote_get(
+    State(state): State<AppState>,
+    Path(quote_id): Path<String>,
+) -> axum::response::Response {
+    let mut cache = state.quote_cache.lock().await;
+    if let Some((price, _task_id)) = cache.get(&quote_id) {
+        let status = if price.is_some() {
+            StatusCode::OK
+        } else {
+            StatusCode::ACCEPTED
+        };
+        (
+            status,
+            Json(QuoteResponse {
+                quote_id,
+                price: price.clone(),
+            }),
+        )
+            .into_response()
+    } else {
+        let problem = ProblemJson::from_status(
+            StatusCode::NOT_FOUND,
+            Some("Quote not found".to_string()),
+            Some(format!("/v1/backups/quote/{}", quote_id)),
+        );
+        problem.into_response()
+    }
+}
+
+#[cfg(test)]
+mod handle_backup_quote_tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::http::{Request, StatusCode};
+    use axum::{routing::get, routing::post, Extension, Router};
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
+    use tokio::sync::{mpsc, Mutex};
+    use tower::Service;
+
+    use crate::ipfs::IpfsPinningConfig;
+    use crate::server::database::Db;
+    use crate::server::x402::{X402Config, X402ConfigRaw, X402FacilitatorConfigRaw};
+    use crate::server::AppState;
+
+    fn make_state_with_x402(ipfs_pinning_configs: Vec<IpfsPinningConfig>) -> AppState {
+        let mut chains = HashMap::new();
+        chains.insert("ethereum".to_string(), "rpc://dummy".to_string());
+        let chain_config = crate::ChainConfig(chains);
+        let (tx, _rx) = mpsc::channel(1);
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://user:pass@localhost/db")
+            .unwrap();
+        let db = Arc::new(Db { pool });
+
+        let x402_config_raw = X402ConfigRaw {
+            asset_symbol: "USDC".to_string(),
+            base_url: "http://localhost:8080/".to_string(),
+            recipient_address: "0x1234567890123456789012345678901234567890".to_string(),
+            max_timeout_seconds: 300,
+            price: "0.1".to_string(),
+            facilitator: X402FacilitatorConfigRaw {
+                url: "https://x402.org/facilitator".to_string(),
+                network: "base-sepolia".to_string(),
+                api_key_id_env: None,
+                api_key_secret_env: None,
+            },
+        };
+        let x402_config = X402Config::compile(x402_config_raw).unwrap();
+
+        AppState {
+            chain_config: Arc::new(chain_config),
+            base_dir: Arc::new("/tmp".to_string()),
+            unsafe_skip_checksum_check: true,
+            auth_token: None,
+            pruner_retention_days: 7,
+            download_tokens: Arc::new(Mutex::new(HashMap::new())),
+            quote_cache: Arc::new(Mutex::new(lru::LruCache::new(
+                NonZeroUsize::new(1000).unwrap(),
+            ))),
+            backup_task_sender: tx,
+            db,
+            shutdown_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            ipfs_pinning_configs,
+            ipfs_pinning_instances: Arc::new(Vec::new()),
+            x402_config: Some(x402_config),
+        }
+    }
+
+    fn make_state_without_x402(ipfs_pinning_configs: Vec<IpfsPinningConfig>) -> AppState {
+        let mut chains = HashMap::new();
+        chains.insert("ethereum".to_string(), "rpc://dummy".to_string());
+        let chain_config = crate::ChainConfig(chains);
+        let (tx, _rx) = mpsc::channel(1);
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://user:pass@localhost/db")
+            .unwrap();
+        let db = Arc::new(Db { pool });
+        AppState {
+            chain_config: Arc::new(chain_config),
+            base_dir: Arc::new("/tmp".to_string()),
+            unsafe_skip_checksum_check: true,
+            auth_token: None,
+            pruner_retention_days: 7,
+            download_tokens: Arc::new(Mutex::new(HashMap::new())),
+            quote_cache: Arc::new(Mutex::new(lru::LruCache::new(
+                NonZeroUsize::new(1000).unwrap(),
+            ))),
+            backup_task_sender: tx,
+            db,
+            shutdown_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            ipfs_pinning_configs,
+            ipfs_pinning_instances: Arc::new(Vec::new()),
+            x402_config: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn creates_quote_successfully() {
+        let state = make_state_with_x402(Vec::new());
+        let mut app = Router::new()
+            .route("/quote", post(handle_backup_quote))
+            .with_state(state)
+            .layer(Extension::<Option<String>>(None));
+
+        let req_body = json!({
+            "tokens": [
+                {
+                    "chain": "ethereum",
+                    "tokens": ["0x123:1"]
+                }
+            ],
+            "pin_on_ipfs": false,
+            "create_archive": true
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/quote")
+            .header("content-type", "application/json")
+            .body(serde_json::to_string(&req_body).unwrap())
+            .unwrap();
+
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let quote_resp: QuoteCreateResponse = serde_json::from_slice(&body).unwrap();
+        assert!(!quote_resp.quote_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn returns_500_when_x402_config_missing() {
+        let state = make_state_without_x402(Vec::new());
+        let mut app = Router::new()
+            .route("/quote", post(handle_backup_quote))
+            .with_state(state)
+            .layer(Extension::<Option<String>>(None));
+
+        let req_body = json!({
+            "tokens": [
+                {
+                    "chain": "ethereum",
+                    "tokens": ["0x123:1"]
+                }
+            ],
+            "pin_on_ipfs": false,
+            "create_archive": true
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/quote")
+            .header("content-type", "application/json")
+            .body(serde_json::to_string(&req_body).unwrap())
+            .unwrap();
+
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn returns_400_for_invalid_request() {
+        let state = make_state_with_x402(Vec::new());
+        let mut app = Router::new()
+            .route("/quote", post(handle_backup_quote))
+            .with_state(state)
+            .layer(Extension::<Option<String>>(None));
+
+        let req_body = json!({
+            "tokens": [
+                {
+                    "chain": "unknown_chain",
+                    "tokens": ["0x123:1"]
+                }
+            ],
+            "pin_on_ipfs": false,
+            "create_archive": true
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/quote")
+            .header("content-type", "application/json")
+            .body(serde_json::to_string(&req_body).unwrap())
+            .unwrap();
+
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn gets_quote_successfully() {
+        let state = make_state_with_x402(Vec::new());
+        let mut app = Router::new()
+            .route("/quote", post(handle_backup_quote))
+            .route("/quote/{quote_id}", get(handle_backup_quote_get))
+            .with_state(state.clone())
+            .layer(Extension::<Option<String>>(None));
+
+        // First create a quote
+        let req_body = json!({
+            "tokens": [
+                {
+                    "chain": "ethereum",
+                    "tokens": ["0x123:1"]
+                }
+            ],
+            "pin_on_ipfs": false,
+            "create_archive": true
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/quote")
+            .header("content-type", "application/json")
+            .body(serde_json::to_string(&req_body).unwrap())
+            .unwrap();
+
+        let resp = app.call(req).await.unwrap();
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let quote_resp: QuoteCreateResponse = serde_json::from_slice(&body).unwrap();
+        let quote_id = quote_resp.quote_id;
+
+        // Now get the quote
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/quote/{}", quote_id))
+            .body(String::new())
+            .unwrap();
+
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let quote: QuoteResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(quote.quote_id, quote_id);
+        assert_eq!(quote.price, Some("0.1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn returns_404_for_nonexistent_quote() {
+        let state = make_state_with_x402(Vec::new());
+        let mut app = Router::new()
+            .route("/quote/{quote_id}", get(handle_backup_quote_get))
+            .with_state(state)
+            .layer(Extension::<Option<String>>(None));
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/quote/nonexistent-id")
+            .body(String::new())
+            .unwrap();
+
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/src/server/handlers/handle_pins.rs
+++ b/src/server/handlers/handle_pins.rs
@@ -406,10 +406,10 @@ mod handle_pins_core_mockdb_tests {
 #[cfg(test)]
 mod handle_pins_endpoint_tests {
     use super::handle_pins;
-    use axum::http::StatusCode;
+    use axum::http::{Request, StatusCode};
     use axum::{routing::get, Extension, Router};
-    use hyper::Request;
     use std::collections::HashMap;
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
     use tokio::sync::Mutex;
     use tower::Service;
@@ -434,11 +434,15 @@ mod handle_pins_endpoint_tests {
             auth_token: None,
             pruner_retention_days: 7,
             download_tokens: Arc::new(Mutex::new(HashMap::new())),
+            quote_cache: Arc::new(Mutex::new(lru::LruCache::new(
+                NonZeroUsize::new(1000).unwrap(),
+            ))),
             backup_task_sender: tx,
             db,
             shutdown_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             ipfs_pinning_configs,
             ipfs_pinning_instances: Arc::new(Vec::new()),
+            x402_config: None,
         }
     }
 

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod handle_backup;
 pub mod handle_backup_create;
 pub mod handle_backup_delete_archive;
 pub mod handle_backup_delete_pins;
+pub mod handle_backup_quote;
 pub mod handle_backup_retries;
 pub mod handle_backups;
 pub mod handle_pins;

--- a/src/server/x402/dynamic_price.rs
+++ b/src/server/x402/dynamic_price.rs
@@ -1,0 +1,266 @@
+use axum::http::HeaderMap;
+use tracing::warn;
+use url::Url;
+
+use crate::server::x402::X402Config;
+use crate::server::AppState;
+use x402_axum::layer::X402Error;
+use x402_rs::types::TokenAmount;
+
+/// Parse a price string (e.g., "0.1069") directly to microdollars (u64)
+/// without using floating-point arithmetic to avoid precision loss.
+/// USDC has 6 decimal places, so we multiply by 1_000_000.
+fn parse_price_to_microdollars(price_str: &str) -> Result<u64, String> {
+    let price_str = price_str.trim();
+    if price_str.is_empty() {
+        return Err("Price string is empty".to_string());
+    }
+
+    let parts: Vec<&str> = price_str.split('.').collect();
+    if parts.len() > 2 {
+        return Err("Invalid price format: multiple decimal points".to_string());
+    }
+
+    let whole_part = parts[0]
+        .parse::<u64>()
+        .map_err(|e| format!("Failed to parse whole part '{}': {}", parts[0], e))?;
+
+    let fractional_part = if parts.len() == 2 {
+        let frac_str = parts[1];
+        if frac_str.is_empty() {
+            0
+        } else if frac_str.len() > 6 {
+            return Err(format!(
+                "Price has more than 6 decimal places: {}",
+                frac_str.len()
+            ));
+        } else {
+            let frac_value = frac_str
+                .parse::<u64>()
+                .map_err(|e| format!("Failed to parse fractional part '{}': {}", frac_str, e))?;
+            // Scale fractional part to microdollars by multiplying by 10^(6 - len)
+            // e.g., "1069" (4 digits) -> 1069 * 10^2 = 106900
+            let scale = 6 - frac_str.len();
+            frac_value
+                .checked_mul(10_u64.pow(scale as u32))
+                .ok_or_else(|| "Fractional part too large, would overflow".to_string())?
+        }
+    } else {
+        0
+    };
+
+    let microdollars = whole_part
+        .checked_mul(1_000_000)
+        .and_then(|w| w.checked_add(fractional_part))
+        .ok_or_else(|| "Price value too large, would overflow".to_string())?;
+
+    Ok(microdollars)
+}
+
+async fn compute_dynamic_price_impl(
+    state: AppState,
+    config: X402Config,
+    quote_id: Option<String>,
+) -> Result<TokenAmount, X402Error> {
+    let quote_id = quote_id.ok_or_else(|| {
+        X402Error::verification_failed("X-Quote-Id header is required".to_string(), Vec::new())
+    })?;
+
+    let mut cache = state.quote_cache.lock().await;
+    let (price_opt, _) = cache.get(&quote_id).ok_or_else(|| {
+        X402Error::verification_failed(format!("Quote {quote_id} not found in cache"), Vec::new())
+    })?;
+
+    let price_str = price_opt.clone().ok_or_else(|| {
+        X402Error::verification_failed(
+            format!("Quote {quote_id} exists but has no price set"),
+            Vec::new(),
+        )
+    })?;
+
+    drop(cache);
+
+    // Validate the price tag
+    let _price_tag = config.usdc_price_tag_for_amount(&price_str).map_err(|e| {
+        let error_msg = format!(
+            "Failed to build price tag from amount '{}': {}",
+            price_str, e
+        );
+        warn!("{}", error_msg);
+        X402Error::verification_failed(error_msg, Vec::new())
+    })?;
+
+    // Parse price string directly as integer microdollars to avoid floating-point precision issues
+    // USDC has 6 decimal places, so we convert dollars to microdollars (multiply by 1_000_000)
+    let token_amount = parse_price_to_microdollars(&price_str).map_err(|e| {
+        let error_msg = format!("Failed to parse price '{}': {}", price_str, e);
+        warn!("{}", error_msg);
+        X402Error::verification_failed(error_msg, Vec::new())
+    })?;
+    let token_amount = TokenAmount::from(token_amount);
+
+    Ok(token_amount)
+}
+
+pub fn create_dynamic_price_callback(
+    state: AppState,
+    config: X402Config,
+) -> Box<x402_axum::layer::DynamicPriceCallback> {
+    Box::new(
+        move |headers: &HeaderMap, _uri: &axum::http::Uri, _base_url: &Url| {
+            let state = state.clone();
+            let config = config.clone();
+            let quote_id = headers
+                .get("X-Quote-Id")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+
+            Box::pin(compute_dynamic_price_impl(state, config, quote_id))
+        },
+    )
+}
+
+#[cfg(test)]
+mod parse_price_to_microdollars_tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_whole_number() {
+        assert_eq!(parse_price_to_microdollars("0"), Ok(0));
+        assert_eq!(parse_price_to_microdollars("1"), Ok(1_000_000));
+        assert_eq!(parse_price_to_microdollars("10"), Ok(10_000_000));
+        assert_eq!(parse_price_to_microdollars("100"), Ok(100_000_000));
+    }
+
+    #[test]
+    fn test_parse_with_decimal_places() {
+        assert_eq!(parse_price_to_microdollars("0.1"), Ok(100_000));
+        assert_eq!(parse_price_to_microdollars("0.01"), Ok(10_000));
+        assert_eq!(parse_price_to_microdollars("0.001"), Ok(1_000));
+        assert_eq!(parse_price_to_microdollars("0.0001"), Ok(100));
+        assert_eq!(parse_price_to_microdollars("0.00001"), Ok(10));
+        assert_eq!(parse_price_to_microdollars("0.000001"), Ok(1));
+    }
+
+    #[test]
+    fn test_parse_with_partial_decimal_places() {
+        assert_eq!(parse_price_to_microdollars("0.1069"), Ok(106_900));
+        assert_eq!(parse_price_to_microdollars("1.5"), Ok(1_500_000));
+        assert_eq!(parse_price_to_microdollars("10.25"), Ok(10_250_000));
+        assert_eq!(parse_price_to_microdollars("100.123456"), Ok(100_123_456));
+    }
+
+    #[test]
+    fn test_parse_with_whitespace() {
+        assert_eq!(parse_price_to_microdollars(" 0.1 "), Ok(100_000));
+        assert_eq!(parse_price_to_microdollars("1.5 "), Ok(1_500_000));
+        assert_eq!(parse_price_to_microdollars(" 10"), Ok(10_000_000));
+    }
+
+    #[test]
+    fn test_parse_large_values() {
+        assert_eq!(parse_price_to_microdollars("1000"), Ok(1_000_000_000));
+        assert_eq!(parse_price_to_microdollars("10000"), Ok(10_000_000_000));
+        assert_eq!(parse_price_to_microdollars("100000"), Ok(100_000_000_000));
+    }
+
+    #[test]
+    fn test_parse_empty_string() {
+        let result = parse_price_to_microdollars("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Price string is empty"));
+    }
+
+    #[test]
+    fn test_parse_whitespace_only() {
+        let result = parse_price_to_microdollars("   ");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Price string is empty"));
+    }
+
+    #[test]
+    fn test_parse_multiple_decimal_points() {
+        let result = parse_price_to_microdollars("1.2.3");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Invalid price format: multiple decimal points"));
+    }
+
+    #[test]
+    fn test_parse_too_many_decimal_places() {
+        let result = parse_price_to_microdollars("0.1234567");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Price has more than 6 decimal places"));
+    }
+
+    #[test]
+    fn test_parse_exactly_six_decimal_places() {
+        assert_eq!(parse_price_to_microdollars("0.123456"), Ok(123_456));
+        assert_eq!(parse_price_to_microdollars("1.123456"), Ok(1_123_456));
+    }
+
+    #[test]
+    fn test_parse_invalid_characters() {
+        let result = parse_price_to_microdollars("abc");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to parse whole part"));
+
+        let result = parse_price_to_microdollars("1.abc");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Failed to parse fractional part"));
+    }
+
+    #[test]
+    fn test_parse_negative_number() {
+        let result = parse_price_to_microdollars("-1");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to parse whole part"));
+    }
+
+    #[test]
+    fn test_parse_decimal_point_only() {
+        let result = parse_price_to_microdollars(".");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_leading_decimal_point() {
+        let result = parse_price_to_microdollars(".5");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to parse whole part"));
+    }
+
+    #[test]
+    fn test_parse_trailing_decimal_point() {
+        let result = parse_price_to_microdollars("5.");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 5_000_000);
+    }
+
+    #[test]
+    fn test_parse_edge_case_zero_with_decimal() {
+        assert_eq!(parse_price_to_microdollars("0.0"), Ok(0));
+        assert_eq!(parse_price_to_microdollars("0.00"), Ok(0));
+        assert_eq!(parse_price_to_microdollars("0.000000"), Ok(0));
+    }
+
+    #[test]
+    fn test_parse_very_small_amounts() {
+        assert_eq!(parse_price_to_microdollars("0.000001"), Ok(1));
+        assert_eq!(parse_price_to_microdollars("0.000010"), Ok(10));
+        assert_eq!(parse_price_to_microdollars("0.000100"), Ok(100));
+    }
+
+    #[test]
+    fn test_parse_common_price_examples() {
+        assert_eq!(parse_price_to_microdollars("0.01"), Ok(10_000));
+        assert_eq!(parse_price_to_microdollars("0.1"), Ok(100_000));
+        assert_eq!(parse_price_to_microdollars("1.0"), Ok(1_000_000));
+        assert_eq!(parse_price_to_microdollars("10.50"), Ok(10_500_000));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces quote APIs and an LRU-backed quote cache, integrates dynamic x402 pricing (via X-Quote-Id) into backup creation, and updates the CLI to request/consume quotes before creating backups.
> 
> - **Backend**:
>   - **Quote APIs**: Add `POST /v1/backups/quote` and `GET /v1/backups/quote/{quote_id}` with new schema types (`QuoteCreateResponse`, `QuoteResponse`).
>   - **Dynamic Pricing**: Wire x402 middleware with a dynamic price callback; validate `X-Quote-Id` in `POST /v1/backups` against an in-memory LRU `quote_cache`.
>   - **State/Config**: Extend `AppState` with `quote_cache` and `x402_config`; add `quote_cache_size` to `ServerConfig` and initialization; expose routes in the router.
> - **CLI**:
>   - Request a quote, poll until ready, then submit backup including `X-Quote-Id`; handle servers without quote support gracefully.
> - **Config/Flags**:
>   - New server flag `--quote_cache_size` to bound in-memory quote storage.
> - **Tests**:
>   - Add comprehensive tests for quote lifecycle, validation, and dynamic pricing parsing; update existing tests to include cache where needed.
> - **Dependencies**:
>   - Add `lru`; bump `x402-axum` and `x402-rs` plus minor crate updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59f7199f7283c720336f5d3296bed6f1cf4c753a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





Partially addresses https://github.com/0xmichalis/nftbk/issues/47

We still need to implement functionality to generate proper quotes on requests