### PR TITLE
refactor: move status types from strings to enums

### DIFF
--- a/src/ipfs/provider.rs
+++ b/src/ipfs/provider.rs
@@ -40,6 +40,17 @@ pub enum PinResponseStatus {
     Failed,
 }
 
+impl PinResponseStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PinResponseStatus::Queued => "queued",
+            PinResponseStatus::Pinning => "pinning",
+            PinResponseStatus::Pinned => "pinned",
+            PinResponseStatus::Failed => "failed",
+        }
+    }
+}
+
 /// Trait for IPFS pinning providers
 #[async_trait]
 pub trait IpfsPinningProvider: Send + Sync {

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -131,7 +131,10 @@ impl BackupResponse {
         limit: u32,
     ) -> Self {
         let archive_status = SubresourceStatus {
-            status: task.archive_status.clone(),
+            status: task
+                .archive_status
+                .as_ref()
+                .map(|s: &crate::server::database::ArchiveStatus| s.as_str().to_string()),
             fatal_error: task.archive_fatal_error.clone(),
             error_log: task.archive_error_log.clone(),
             deleted_at: task
@@ -140,7 +143,10 @@ impl BackupResponse {
                 .map(|d: &DateTime<Utc>| d.to_rfc3339()),
         };
         let pins_status = SubresourceStatus {
-            status: task.ipfs_status.clone(),
+            status: task
+                .ipfs_status
+                .as_ref()
+                .map(|s: &crate::server::database::IpfsStatus| s.as_str().to_string()),
             fatal_error: task.ipfs_fatal_error.clone(),
             error_log: task.ipfs_error_log.clone(),
             deleted_at: task
@@ -179,7 +185,7 @@ impl BackupResponse {
 #[cfg(test)]
 mod from_backup_task_tests {
     use super::{BackupResponse, Tokens};
-    use crate::server::database::BackupTask;
+    use crate::server::database::{ArchiveStatus, BackupTask, IpfsStatus};
     use chrono::{TimeZone, Utc};
 
     fn sample_task() -> BackupTask {
@@ -190,8 +196,8 @@ mod from_backup_task_tests {
             requestor: "did:privy:alice".to_string(),
             nft_count: 3,
             tokens: serde_json::json!([]),
-            archive_status: Some("done".to_string()),
-            ipfs_status: Some("in_progress".to_string()),
+            archive_status: Some(ArchiveStatus::Done),
+            ipfs_status: Some(IpfsStatus::InProgress),
             archive_error_log: Some("arch warnings".to_string()),
             ipfs_error_log: None,
             archive_fatal_error: None,

--- a/src/server/database/mod.rs
+++ b/src/server/database/mod.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -5,10 +6,105 @@ use serde::{Deserialize, Serialize};
 use sqlx::{postgres::PgPoolOptions, PgPool, Row};
 use tracing::{info, warn};
 
+use crate::ipfs::PinResponseStatus;
 use crate::server::database::r#trait::Database;
 use crate::server::StorageMode;
 
 pub mod r#trait;
+
+/// Status of an archive request (backup archive stored on disk)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ArchiveStatus {
+    InProgress,
+    Done,
+    Error,
+    Expired,
+}
+
+impl ArchiveStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ArchiveStatus::InProgress => "in_progress",
+            ArchiveStatus::Done => "done",
+            ArchiveStatus::Error => "error",
+            ArchiveStatus::Expired => "expired",
+        }
+    }
+}
+
+impl fmt::Display for ArchiveStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Status of an IPFS pin request
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IpfsStatus {
+    InProgress,
+    Done,
+    Error,
+}
+
+impl IpfsStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            IpfsStatus::InProgress => "in_progress",
+            IpfsStatus::Done => "done",
+            IpfsStatus::Error => "error",
+        }
+    }
+}
+
+impl fmt::Display for IpfsStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Parse an optional status string from the database into an enum variant.
+fn parse_archive_status(s: Option<String>) -> Option<ArchiveStatus> {
+    s.as_deref().and_then(|s| match s {
+        "in_progress" => Some(ArchiveStatus::InProgress),
+        "done" => Some(ArchiveStatus::Done),
+        "error" => Some(ArchiveStatus::Error),
+        "expired" => Some(ArchiveStatus::Expired),
+        _ => {
+            warn!("Unknown archive status string: {s}");
+            None
+        }
+    })
+}
+
+/// Parse an optional IPFS status string from the database into an enum variant.
+fn parse_ipfs_status(s: Option<String>) -> Option<IpfsStatus> {
+    s.as_deref().and_then(|s| match s {
+        "in_progress" => Some(IpfsStatus::InProgress),
+        "done" => Some(IpfsStatus::Done),
+        "error" => Some(IpfsStatus::Error),
+        _ => {
+            warn!("Unknown IPFS status string: {s}");
+            None
+        }
+    })
+}
+
+/// Parse a pin status string from the database into a PinResponseStatus.
+fn parse_pin_status(s: String) -> PinResponseStatus {
+    match s.as_str() {
+        "queued" => PinResponseStatus::Queued,
+        "pinning" => PinResponseStatus::Pinning,
+        "pinned" => PinResponseStatus::Pinned,
+        "failed" => PinResponseStatus::Failed,
+        other => {
+            warn!("Unknown pin status string: {other}");
+            // Default to a safe fallback
+            PinResponseStatus::Failed
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BackupTask {
@@ -18,8 +114,8 @@ pub struct BackupTask {
     pub requestor: String,
     pub nft_count: i32,
     pub tokens: serde_json::Value,
-    pub archive_status: Option<String>,
-    pub ipfs_status: Option<String>,
+    pub archive_status: Option<ArchiveStatus>,
+    pub ipfs_status: Option<IpfsStatus>,
     pub archive_error_log: Option<String>,
     pub ipfs_error_log: Option<String>,
     pub archive_fatal_error: Option<String>,
@@ -75,7 +171,7 @@ pub struct PinRow {
     pub provider_url: Option<String>,
     pub cid: String,
     pub request_id: String,
-    pub pin_status: String,
+    pub pin_status: PinResponseStatus,
     pub created_at: DateTime<Utc>,
 }
 
@@ -345,7 +441,7 @@ impl Db {
     pub async fn update_pin_request_status(
         &self,
         task_id: &str,
-        status: &str,
+        status: &IpfsStatus,
     ) -> Result<(), sqlx::Error> {
         sqlx::query(
             r#"
@@ -355,11 +451,11 @@ impl Db {
             "#,
         )
         .bind(task_id)
-        .bind(status)
+        .bind(status.as_str())
         .execute(&self.pool)
         .await?;
 
-        Self::log_status(task_id, status, &StorageMode::Ipfs);
+        Self::log_status(task_id, status.as_str(), &StorageMode::Ipfs);
 
         Ok(())
     }
@@ -367,7 +463,7 @@ impl Db {
     pub async fn update_archive_request_status(
         &self,
         task_id: &str,
-        status: &str,
+        status: &ArchiveStatus,
     ) -> Result<(), sqlx::Error> {
         sqlx::query(
             r#"
@@ -377,11 +473,11 @@ impl Db {
             "#,
         )
         .bind(task_id)
-        .bind(status)
+        .bind(status.as_str())
         .execute(&self.pool)
         .await?;
 
-        Self::log_status(task_id, status, &StorageMode::Archive);
+        Self::log_status(task_id, status.as_str(), &StorageMode::Archive);
 
         Ok(())
     }
@@ -389,7 +485,7 @@ impl Db {
     pub async fn update_archive_request_statuses(
         &self,
         task_ids: &[String],
-        status: &str,
+        status: &ArchiveStatus,
     ) -> Result<(), sqlx::Error> {
         if task_ids.is_empty() {
             return Ok(());
@@ -401,7 +497,7 @@ impl Db {
         // Update each task_id individually with a prepared statement
         for task_id in task_ids {
             sqlx::query("UPDATE archive_requests SET status = $1 WHERE task_id = $2")
-                .bind(status)
+                .bind(status.as_str())
                 .bind(task_id)
                 .execute(&mut *tx)
                 .await?;
@@ -695,14 +791,16 @@ impl Db {
                 requestor: row.get("requestor"),
                 nft_count: row.get("nft_count"),
                 tokens: tokens_json,
-                archive_status: row
-                    .try_get::<Option<String>, _>("archive_status")
-                    .ok()
-                    .flatten(),
-                ipfs_status: row
-                    .try_get::<Option<String>, _>("ipfs_status")
-                    .ok()
-                    .flatten(),
+                archive_status: parse_archive_status(
+                    row.try_get::<Option<String>, _>("archive_status")
+                        .ok()
+                        .flatten(),
+                ),
+                ipfs_status: parse_ipfs_status(
+                    row.try_get::<Option<String>, _>("ipfs_status")
+                        .ok()
+                        .flatten(),
+                ),
                 archive_error_log: row.get("archive_error_log"),
                 ipfs_error_log: row.get("ipfs_error_log"),
                 archive_fatal_error: row.get("fatal_error"),
@@ -800,14 +898,16 @@ impl Db {
             requestor: row.get("requestor"),
             nft_count: row.get("nft_count"),
             tokens: tokens_json,
-            archive_status: row
-                .try_get::<Option<String>, _>("archive_status")
-                .ok()
-                .flatten(),
-            ipfs_status: row
-                .try_get::<Option<String>, _>("ipfs_status")
-                .ok()
-                .flatten(),
+            archive_status: parse_archive_status(
+                row.try_get::<Option<String>, _>("archive_status")
+                    .ok()
+                    .flatten(),
+            ),
+            ipfs_status: parse_ipfs_status(
+                row.try_get::<Option<String>, _>("ipfs_status")
+                    .ok()
+                    .flatten(),
+            ),
             archive_error_log: row.get("archive_error_log"),
             ipfs_error_log: row.get("ipfs_error_log"),
             archive_fatal_error: row.get("fatal_error"),
@@ -879,14 +979,16 @@ impl Db {
                     // Client should use get_backup_task to get tokens so the tokens
                     // can be properly paginated.
                     tokens: serde_json::Value::Null,
-                    archive_status: row
-                        .try_get::<Option<String>, _>("archive_status")
-                        .ok()
-                        .flatten(),
-                    ipfs_status: row
-                        .try_get::<Option<String>, _>("ipfs_status")
-                        .ok()
-                        .flatten(),
+                    archive_status: parse_archive_status(
+                        row.try_get::<Option<String>, _>("archive_status")
+                            .ok()
+                            .flatten(),
+                    ),
+                    ipfs_status: parse_ipfs_status(
+                        row.try_get::<Option<String>, _>("ipfs_status")
+                            .ok()
+                            .flatten(),
+                    ),
                     archive_error_log: row.get("archive_error_log"),
                     ipfs_error_log: row.get("ipfs_error_log"),
                     archive_fatal_error: row.get("fatal_error"),
@@ -1022,14 +1124,16 @@ impl Db {
                     requestor: row.get("requestor"),
                     nft_count: row.get("nft_count"),
                     tokens: tokens_json,
-                    archive_status: row
-                        .try_get::<Option<String>, _>("archive_status")
-                        .ok()
-                        .flatten(),
-                    ipfs_status: row
-                        .try_get::<Option<String>, _>("ipfs_status")
-                        .ok()
-                        .flatten(),
+                    archive_status: parse_archive_status(
+                        row.try_get::<Option<String>, _>("archive_status")
+                            .ok()
+                            .flatten(),
+                    ),
+                    ipfs_status: parse_ipfs_status(
+                        row.try_get::<Option<String>, _>("ipfs_status")
+                            .ok()
+                            .flatten(),
+                    ),
                     archive_error_log: row.get("archive_error_log"),
                     ipfs_error_log: row.get("ipfs_error_log"),
                     archive_fatal_error: row.get("fatal_error"),
@@ -1162,7 +1266,7 @@ impl Db {
                     .flatten(),
                 cid: row.get("cid"),
                 request_id: row.get("request_id"),
-                pin_status: row.get("pin_status"),
+                pin_status: parse_pin_status(row.get("pin_status")),
                 created_at: row.get("created_at"),
             })
             .collect())
@@ -1371,7 +1475,7 @@ impl Db {
                     .flatten(),
                 cid: row.get("cid"),
                 request_id: row.get("request_id"),
-                pin_status: row.get("pin_status"),
+                pin_status: parse_pin_status(row.get("pin_status")),
                 created_at: row.get("created_at"),
             })
             .collect())
@@ -1428,8 +1532,8 @@ impl Db {
         &self,
         task_id: &str,
         scope: &str,
-        archive_status: &str,
-        ipfs_status: &str,
+        archive_status: &ArchiveStatus,
+        ipfs_status: &IpfsStatus,
     ) -> Result<(), sqlx::Error> {
         let sql = r#"
             WITH upd_archive AS (
@@ -1451,8 +1555,8 @@ impl Db {
         "#;
         sqlx::query(sql)
             .bind(task_id)
-            .bind(archive_status)
-            .bind(ipfs_status)
+            .bind(archive_status.as_str())
+            .bind(ipfs_status.as_str())
             .bind(scope)
             .execute(&self.pool)
             .await?;
@@ -1719,7 +1823,7 @@ impl Database for Db {
     async fn update_archive_request_status(
         &self,
         task_id: &str,
-        status: &str,
+        status: &ArchiveStatus,
     ) -> Result<(), sqlx::Error> {
         Db::update_archive_request_status(self, task_id, status).await
     }
@@ -1727,7 +1831,7 @@ impl Database for Db {
     async fn update_pin_request_status(
         &self,
         task_id: &str,
-        status: &str,
+        status: &IpfsStatus,
     ) -> Result<(), sqlx::Error> {
         Db::update_pin_request_status(self, task_id, status).await
     }
@@ -1736,8 +1840,8 @@ impl Database for Db {
         &self,
         task_id: &str,
         scope: &str,
-        archive_status: &str,
-        ipfs_status: &str,
+        archive_status: &ArchiveStatus,
+        ipfs_status: &IpfsStatus,
     ) -> Result<(), sqlx::Error> {
         Db::update_backup_statuses(self, task_id, scope, archive_status, ipfs_status).await
     }
@@ -1745,7 +1849,7 @@ impl Database for Db {
     async fn update_archive_request_statuses(
         &self,
         task_ids: &[String],
-        status: &str,
+        status: &ArchiveStatus,
     ) -> Result<(), sqlx::Error> {
         Db::update_archive_request_statuses(self, task_ids, status).await
     }

--- a/src/server/database/trait.rs
+++ b/src/server/database/trait.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 use serde_json;
 use sqlx;
 
-use crate::server::database::{ArchiveStatus, BackupTask, ExpiredBackup, IpfsStatus, PinRow, TokenWithPins};
+use crate::server::database::{
+    ArchiveStatus, BackupTask, ExpiredBackup, IpfsStatus, PinRow, TokenWithPins,
+};
 use crate::types::TokenPinMapping;
 
 /// Unified database trait that consolidates all database operations

--- a/src/server/database/trait.rs
+++ b/src/server/database/trait.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use serde_json;
 use sqlx;
 
-use crate::server::database::{BackupTask, ExpiredBackup, PinRow, TokenWithPins};
+use crate::server::database::{ArchiveStatus, BackupTask, ExpiredBackup, IpfsStatus, PinRow, TokenWithPins};
 use crate::types::TokenPinMapping;
 
 /// Unified database trait that consolidates all database operations
@@ -84,27 +84,27 @@ pub trait Database {
     async fn update_archive_request_status(
         &self,
         task_id: &str,
-        status: &str,
+        status: &ArchiveStatus,
     ) -> Result<(), sqlx::Error>;
 
     async fn update_pin_request_status(
         &self,
         task_id: &str,
-        status: &str,
+        status: &IpfsStatus,
     ) -> Result<(), sqlx::Error>;
 
     async fn update_backup_statuses(
         &self,
         task_id: &str,
         scope: &str,
-        archive_status: &str,
-        ipfs_status: &str,
+        archive_status: &ArchiveStatus,
+        ipfs_status: &IpfsStatus,
     ) -> Result<(), sqlx::Error>;
 
     async fn update_archive_request_statuses(
         &self,
         task_ids: &[String],
-        status: &str,
+        status: &ArchiveStatus,
     ) -> Result<(), sqlx::Error>;
 
     // Upgrade operations
@@ -598,7 +598,7 @@ impl Database for MockDatabase {
     async fn update_archive_request_status(
         &self,
         _task_id: &str,
-        _status: &str,
+        _status: &ArchiveStatus,
     ) -> Result<(), sqlx::Error> {
         if let Some(error) = &self.update_archive_request_status_error {
             Err(sqlx::Error::Configuration(error.clone().into()))
@@ -610,7 +610,7 @@ impl Database for MockDatabase {
     async fn update_pin_request_status(
         &self,
         _task_id: &str,
-        _status: &str,
+        _status: &IpfsStatus,
     ) -> Result<(), sqlx::Error> {
         if let Some(error) = &self.update_pin_request_status_error {
             Err(sqlx::Error::Configuration(error.clone().into()))
@@ -623,8 +623,8 @@ impl Database for MockDatabase {
         &self,
         _task_id: &str,
         _scope: &str,
-        _archive_status: &str,
-        _ipfs_status: &str,
+        _archive_status: &ArchiveStatus,
+        _ipfs_status: &IpfsStatus,
     ) -> Result<(), sqlx::Error> {
         if let Some(error) = &self.update_backup_statuses_error {
             Err(sqlx::Error::Configuration(error.clone().into()))
@@ -636,7 +636,7 @@ impl Database for MockDatabase {
     async fn update_archive_request_statuses(
         &self,
         _task_ids: &[String],
-        _status: &str,
+        _status: &ArchiveStatus,
     ) -> Result<(), sqlx::Error> {
         if let Some(error) = &self.update_archive_request_statuses_error {
             Err(sqlx::Error::Configuration(error.clone().into()))

--- a/src/server/handlers/handle_archive_download.rs
+++ b/src/server/handlers/handle_archive_download.rs
@@ -15,8 +15,8 @@ use tokio_util::io::ReaderStream;
 use tracing::error;
 
 use crate::server::api::{ApiProblem, ProblemJson};
-use crate::server::database::ArchiveStatus;
 use crate::server::database::r#trait::Database;
+use crate::server::database::ArchiveStatus;
 use crate::server::handlers::verify_requestor_owns_task;
 use crate::server::{archive::check_backup_on_disk, AppState};
 
@@ -267,6 +267,7 @@ mod handle_download_tests {
     use tokio::sync::{mpsc, Mutex};
 
     use crate::server::database::r#trait::MockDatabase;
+    use crate::server::database::ArchiveStatus;
     use crate::server::handlers::verify_requestor_owns_task;
     use crate::server::AppState;
     use crate::server::Db;

--- a/src/server/handlers/handle_archive_download.rs
+++ b/src/server/handlers/handle_archive_download.rs
@@ -15,6 +15,7 @@ use tokio_util::io::ReaderStream;
 use tracing::error;
 
 use crate::server::api::{ApiProblem, ProblemJson};
+use crate::server::database::ArchiveStatus;
 use crate::server::database::r#trait::Database;
 use crate::server::handlers::verify_requestor_owns_task;
 use crate::server::{archive::check_backup_on_disk, AppState};
@@ -169,7 +170,7 @@ async fn serve_zip_file_for_token_core<DB: Database + ?Sized>(
         }
     };
     // Allow download only when archive subresource is done
-    if meta.archive_status.as_deref().unwrap_or("in_progress") != "done" {
+    if meta.archive_status != Some(ArchiveStatus::Done) {
         return ProblemJson::from_status(
             StatusCode::ACCEPTED,
             Some("Task not completed yet".to_string()),
@@ -326,7 +327,7 @@ mod handle_download_tests {
             requestor: "did:privy:bob".to_string(),
             nft_count: 1,
             tokens: serde_json::json!([]),
-            archive_status: Some("done".to_string()),
+            archive_status: Some(ArchiveStatus::Done),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,
@@ -423,7 +424,7 @@ mod handle_download_tests {
             requestor: "did:privy:alice".to_string(),
             nft_count: 1,
             tokens: serde_json::json!([]),
-            archive_status: Some("done".to_string()),
+            archive_status: Some(ArchiveStatus::Done),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,

--- a/src/server/handlers/handle_backup.rs
+++ b/src/server/handlers/handle_backup.rs
@@ -186,6 +186,7 @@ mod handle_status_core_tests {
     use super::handle_backup_core as handle_status_core;
     use crate::server::api::BackupResponse;
     use crate::server::database::r#trait::MockDatabase;
+    use crate::server::database::ArchiveStatus;
     use crate::server::database::BackupTask;
     use crate::server::handlers::verify_requestor_owns_task;
     use axum::http::StatusCode as AxumStatusCode;
@@ -199,7 +200,7 @@ mod handle_status_core_tests {
             requestor: "did:privy:alice".to_string(),
             nft_count: 1,
             tokens: serde_json::json!([["0xabc:1"]]),
-            archive_status: Some("done".to_string()),
+            archive_status: Some(ArchiveStatus::Done),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,

--- a/src/server/handlers/handle_backup_create.rs
+++ b/src/server/handlers/handle_backup_create.rs
@@ -11,6 +11,7 @@ use tracing::{debug, error, info};
 use crate::server::api::{ApiProblem, BackupCreateResponse, BackupRequest, ProblemJson};
 use crate::server::archive::negotiate_archive_format;
 use crate::server::database::r#trait::Database;
+use crate::server::database::{ArchiveStatus, IpfsStatus};
 use crate::server::hashing::compute_task_id;
 use crate::server::{
     AppState, BackupTask, BackupTaskOrShutdown, QuoteCache, StorageMode, TaskType,
@@ -18,8 +19,8 @@ use crate::server::{
 
 fn get_status(meta: &crate::server::database::BackupTask, scope: &StorageMode) -> Option<String> {
     match scope {
-        StorageMode::Archive => meta.archive_status.clone(),
-        StorageMode::Ipfs => meta.ipfs_status.clone(),
+        StorageMode::Archive => meta.archive_status.as_ref().map(|s| s.as_str().to_string()),
+        StorageMode::Ipfs => meta.ipfs_status.as_ref().map(|s| s.as_str().to_string()),
         StorageMode::Full => {
             unreachable!("get_status reached with Full scope in POST /backups path")
         }
@@ -406,7 +407,7 @@ mod ensure_backup_exists_unit_tests {
             requestor: "did:test".to_string(),
             nft_count: 1,
             tokens: serde_json::json!([{"chain":"ethereum","tokens":["0xabc:1"]}]),
-            archive_status: Some("done".to_string()),
+            archive_status: Some(ArchiveStatus::Done),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,
@@ -794,7 +795,7 @@ mod handle_backup_core_tests {
             requestor: "did:test".to_string(),
             nft_count: 0,
             tokens: serde_json::Value::Null,
-            archive_status: Some("done".to_string()),
+            archive_status: Some(ArchiveStatus::Done),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,
@@ -843,7 +844,7 @@ mod handle_backup_core_tests {
             requestor: "did:privy:bob".to_string(),
             nft_count: 1,
             tokens: serde_json::json!([]),
-            archive_status: Some("done".to_string()),
+            archive_status: Some(ArchiveStatus::Done),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,
@@ -892,7 +893,7 @@ mod handle_backup_core_tests {
             requestor: "did:test".to_string(),
             nft_count: 1,
             tokens: serde_json::json!([]),
-            archive_status: Some("in_progress".to_string()),
+            archive_status: Some(ArchiveStatus::InProgress),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,
@@ -1189,7 +1190,7 @@ mod handle_backup_core_tests {
             requestor: "did:test".to_string(),
             nft_count: 1,
             tokens: serde_json::json!([{"chain":"ethereum","tokens":["0xabc:1"]}]),
-            archive_status: Some("done".to_string()),
+            archive_status: Some(ArchiveStatus::Done),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,
@@ -1251,7 +1252,7 @@ mod handle_backup_core_tests {
             nft_count: 1,
             tokens: serde_json::json!([{"chain":"ethereum","tokens":["0xabc:1"]}]),
             archive_status: None,
-            ipfs_status: Some("done".to_string()),
+            ipfs_status: Some(IpfsStatus::Done),
             archive_error_log: None,
             ipfs_error_log: None,
             archive_fatal_error: None,
@@ -1399,7 +1400,7 @@ mod get_status_unit_tests {
     fn archive_returns_substatus_or_none() {
         let mut meta = base_meta();
         assert_eq!(get_status(&meta, &StorageMode::Archive), None);
-        meta.archive_status = Some("done".to_string());
+        meta.archive_status = Some(ArchiveStatus::Done);
         assert_eq!(
             get_status(&meta, &StorageMode::Archive),
             Some("done".to_string())
@@ -1411,7 +1412,7 @@ mod get_status_unit_tests {
         let mut meta = base_meta();
         meta.storage_mode = "ipfs".to_string();
         assert_eq!(get_status(&meta, &StorageMode::Ipfs), None);
-        meta.ipfs_status = Some("in_progress".to_string());
+        meta.ipfs_status = Some(IpfsStatus::InProgress);
         assert_eq!(
             get_status(&meta, &StorageMode::Ipfs),
             Some("in_progress".to_string())

--- a/src/server/handlers/handle_backup_create.rs
+++ b/src/server/handlers/handle_backup_create.rs
@@ -11,7 +11,6 @@ use tracing::{debug, error, info};
 use crate::server::api::{ApiProblem, BackupCreateResponse, BackupRequest, ProblemJson};
 use crate::server::archive::negotiate_archive_format;
 use crate::server::database::r#trait::Database;
-use crate::server::database::{ArchiveStatus, IpfsStatus};
 use crate::server::hashing::compute_task_id;
 use crate::server::{
     AppState, BackupTask, BackupTaskOrShutdown, QuoteCache, StorageMode, TaskType,
@@ -396,7 +395,7 @@ mod ensure_backup_exists_unit_tests {
     use super::ensure_backup_exists;
     use crate::server::api::Tokens;
     use crate::server::database::r#trait::MockDatabase;
-    use crate::server::database::BackupTask;
+    use crate::server::database::{ArchiveStatus, BackupTask};
     use crate::server::StorageMode;
 
     fn sample_meta() -> BackupTask {
@@ -711,6 +710,7 @@ mod handle_backup_endpoint_tests {
 mod handle_backup_core_tests {
     use crate::server::api::{BackupRequest, Tokens};
     use crate::server::database::r#trait::MockDatabase;
+    use crate::server::database::{ArchiveStatus, IpfsStatus};
     use axum::body::to_bytes;
     use axum::http::{HeaderMap, StatusCode};
     use axum::response::IntoResponse;
@@ -1371,7 +1371,7 @@ mod validate_scope_unit_tests {
 #[cfg(test)]
 mod get_status_unit_tests {
     use super::get_status;
-    use crate::server::database::BackupTask;
+    use crate::server::database::{ArchiveStatus, BackupTask, IpfsStatus};
     use crate::server::StorageMode;
 
     fn base_meta() -> BackupTask {

--- a/src/server/handlers/handle_backup_delete_archive.rs
+++ b/src/server/handlers/handle_backup_delete_archive.rs
@@ -178,7 +178,11 @@ mod handle_backup_delete_archive_core_tests {
     async fn returns_403_on_owner_mismatch() {
         // owner mismatch should return 403
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:other", ArchiveStatus::Done, "archive")));
+        db.set_get_backup_task_result(Some(sample_meta(
+            "did:other",
+            ArchiveStatus::Done,
+            "archive",
+        )));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_archive_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -189,7 +193,11 @@ mod handle_backup_delete_archive_core_tests {
     #[tokio::test]
     async fn returns_409_when_in_progress() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::InProgress, "archive")));
+        db.set_get_backup_task_result(Some(sample_meta(
+            "did:me",
+            ArchiveStatus::InProgress,
+            "archive",
+        )));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_archive_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await

--- a/src/server/handlers/handle_backup_delete_archive.rs
+++ b/src/server/handlers/handle_backup_delete_archive.rs
@@ -7,6 +7,7 @@ use tracing::{error, info};
 
 use crate::server::api::{ApiProblem, ProblemJson};
 use crate::server::database::r#trait::Database;
+use crate::server::database::ArchiveStatus;
 use crate::server::handlers::verify_requestor_owns_task;
 use crate::server::AppState;
 
@@ -71,7 +72,7 @@ async fn handle_backup_delete_archive_core<DB: Database + ?Sized>(
     }
 
     // Check if task is in progress
-    if matches!(meta.archive_status.as_deref(), Some("in_progress")) {
+    if matches!(meta.archive_status, Some(ArchiveStatus::InProgress)) {
         let problem = ProblemJson::from_status(
             StatusCode::CONFLICT,
             Some("Can only delete completed tasks".to_string()),
@@ -109,12 +110,13 @@ async fn handle_backup_delete_archive_core<DB: Database + ?Sized>(
 mod handle_backup_delete_archive_core_tests {
     use super::handle_backup_delete_archive_core;
     use crate::server::database::r#trait::MockDatabase;
+    use crate::server::database::ArchiveStatus;
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
 
     fn sample_meta(
         owner: &str,
-        status: &str,
+        status: ArchiveStatus,
         storage_mode: &str,
     ) -> crate::server::database::BackupTask {
         use chrono::{TimeZone, Utc};
@@ -125,7 +127,7 @@ mod handle_backup_delete_archive_core_tests {
             requestor: owner.to_string(),
             nft_count: 1,
             tokens: serde_json::json!([{"chain":"ethereum","tokens":["0xabc:1"]}]),
-            archive_status: Some(status.to_string()),
+            archive_status: Some(status),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,
@@ -142,7 +144,7 @@ mod handle_backup_delete_archive_core_tests {
     #[tokio::test]
     async fn returns_401_when_missing_requestor() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "done", "archive")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "archive")));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_archive_core(&db, &tx, "t1", None)
             .await
@@ -176,7 +178,7 @@ mod handle_backup_delete_archive_core_tests {
     async fn returns_403_on_owner_mismatch() {
         // owner mismatch should return 403
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:other", "done", "archive")));
+        db.set_get_backup_task_result(Some(sample_meta("did:other", ArchiveStatus::Done, "archive")));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_archive_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -187,7 +189,7 @@ mod handle_backup_delete_archive_core_tests {
     #[tokio::test]
     async fn returns_409_when_in_progress() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "in_progress", "archive")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::InProgress, "archive")));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_archive_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -198,7 +200,7 @@ mod handle_backup_delete_archive_core_tests {
     #[tokio::test]
     async fn returns_422_when_ipfs_only() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "done", "ipfs")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "ipfs")));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_archive_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -209,7 +211,7 @@ mod handle_backup_delete_archive_core_tests {
     #[tokio::test]
     async fn deletes_archive_task_on_success() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "done", "archive")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "archive")));
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_archive_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -224,7 +226,7 @@ mod handle_backup_delete_archive_core_tests {
     #[tokio::test]
     async fn updates_storage_mode_for_full_task() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "done", "full")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "full")));
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_archive_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await

--- a/src/server/handlers/handle_backup_delete_pins.rs
+++ b/src/server/handlers/handle_backup_delete_pins.rs
@@ -70,7 +70,7 @@ async fn handle_backup_delete_pins_core<DB: Database + ?Sized>(
     }
 
     // Check if task is in progress
-    if matches!(meta.ipfs_status.as_deref(), Some("in_progress")) {
+    if matches!(meta.ipfs_status, Some(IpfsStatus::InProgress)) {
         let problem = ProblemJson::from_status(
             StatusCode::CONFLICT,
             Some("Can only delete completed tasks".to_string()),
@@ -107,14 +107,16 @@ async fn handle_backup_delete_pins_core<DB: Database + ?Sized>(
 #[cfg(test)]
 mod handle_backup_delete_pins_core_tests {
     use super::handle_backup_delete_pins_core;
+    use crate::server::database::IpfsStatus;
     use crate::server::database::r#trait::MockDatabase;
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
 
     fn sample_meta(
         owner: &str,
-        status: &str,
+        status: ArchiveStatus,
         storage_mode: &str,
+        ipfs_status: IpfsStatus,
     ) -> crate::server::database::BackupTask {
         use chrono::{TimeZone, Utc};
         crate::server::database::BackupTask {
@@ -124,8 +126,8 @@ mod handle_backup_delete_pins_core_tests {
             requestor: owner.to_string(),
             nft_count: 1,
             tokens: serde_json::json!([{"chain":"ethereum","tokens":["0xabc:1"]}]),
-            archive_status: Some(status.to_string()),
-            ipfs_status: Some(status.to_string()),
+            archive_status: Some(status),
+            ipfs_status: Some(ipfs_status),
             archive_error_log: None,
             ipfs_error_log: None,
             archive_fatal_error: None,
@@ -141,7 +143,7 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn returns_401_when_missing_requestor() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "done", "ipfs")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "ipfs", IpfsStatus::Done)));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", None)
             .await
@@ -174,7 +176,7 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn returns_403_on_owner_mismatch() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:other", "done", "ipfs")));
+        db.set_get_backup_task_result(Some(sample_meta("did:other", ArchiveStatus::Done, "ipfs", IpfsStatus::Done)));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -185,7 +187,7 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn returns_409_when_in_progress() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "in_progress", "ipfs")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::InProgress, "ipfs", IpfsStatus::InProgress)));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -196,7 +198,7 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn returns_422_when_archive_only() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "done", "archive")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "archive", IpfsStatus::Done)));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -207,7 +209,7 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn deletes_pin_request_on_success() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "done", "ipfs")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "ipfs", IpfsStatus::Done)));
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -222,7 +224,7 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn updates_storage_mode_for_full_task() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "done", "full")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "full", IpfsStatus::Done)));
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await

--- a/src/server/handlers/handle_backup_delete_pins.rs
+++ b/src/server/handlers/handle_backup_delete_pins.rs
@@ -7,6 +7,7 @@ use tracing::{error, info};
 
 use crate::server::api::{ApiProblem, ProblemJson};
 use crate::server::database::r#trait::Database;
+use crate::server::database::IpfsStatus;
 use crate::server::handlers::verify_requestor_owns_task;
 use crate::server::AppState;
 
@@ -107,8 +108,8 @@ async fn handle_backup_delete_pins_core<DB: Database + ?Sized>(
 #[cfg(test)]
 mod handle_backup_delete_pins_core_tests {
     use super::handle_backup_delete_pins_core;
-    use crate::server::database::IpfsStatus;
     use crate::server::database::r#trait::MockDatabase;
+    use crate::server::database::{ArchiveStatus, IpfsStatus};
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
 
@@ -143,7 +144,12 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn returns_401_when_missing_requestor() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "ipfs", IpfsStatus::Done)));
+        db.set_get_backup_task_result(Some(sample_meta(
+            "did:me",
+            ArchiveStatus::Done,
+            "ipfs",
+            IpfsStatus::Done,
+        )));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", None)
             .await
@@ -176,7 +182,12 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn returns_403_on_owner_mismatch() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:other", ArchiveStatus::Done, "ipfs", IpfsStatus::Done)));
+        db.set_get_backup_task_result(Some(sample_meta(
+            "did:other",
+            ArchiveStatus::Done,
+            "ipfs",
+            IpfsStatus::Done,
+        )));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -187,7 +198,12 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn returns_409_when_in_progress() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::InProgress, "ipfs", IpfsStatus::InProgress)));
+        db.set_get_backup_task_result(Some(sample_meta(
+            "did:me",
+            ArchiveStatus::InProgress,
+            "ipfs",
+            IpfsStatus::InProgress,
+        )));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -198,7 +214,12 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn returns_422_when_archive_only() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "archive", IpfsStatus::Done)));
+        db.set_get_backup_task_result(Some(sample_meta(
+            "did:me",
+            ArchiveStatus::Done,
+            "archive",
+            IpfsStatus::Done,
+        )));
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -209,7 +230,12 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn deletes_pin_request_on_success() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "ipfs", IpfsStatus::Done)));
+        db.set_get_backup_task_result(Some(sample_meta(
+            "did:me",
+            ArchiveStatus::Done,
+            "ipfs",
+            IpfsStatus::Done,
+        )));
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await
@@ -224,7 +250,12 @@ mod handle_backup_delete_pins_core_tests {
     #[tokio::test]
     async fn updates_storage_mode_for_full_task() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done, "full", IpfsStatus::Done)));
+        db.set_get_backup_task_result(Some(sample_meta(
+            "did:me",
+            ArchiveStatus::Done,
+            "full",
+            IpfsStatus::Done,
+        )));
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let resp = handle_backup_delete_pins_core(&db, &tx, "t1", Some("did:me".to_string()))
             .await

--- a/src/server/handlers/handle_backup_retries.rs
+++ b/src/server/handlers/handle_backup_retries.rs
@@ -8,6 +8,7 @@ use tracing::{error, info};
 
 use crate::server::api::{ApiProblem, BackupCreateResponse, BackupRequest, ProblemJson};
 use crate::server::database::r#trait::Database;
+use crate::server::database::{ArchiveStatus, IpfsStatus};
 use crate::server::handlers::verify_requestor_owns_task;
 use crate::server::{
     parse_scope, AppState, BackupTask, BackupTaskOrShutdown, StorageMode, TaskType, Tokens,
@@ -27,14 +28,14 @@ fn validate_scope_for_retry(
         StorageMode::Ipfs => (false, true),
         StorageMode::Full => (true, true),
     };
-    let archive_status = meta.archive_status.as_deref().unwrap_or("in_progress");
+    let archive_status = meta.archive_status.unwrap_or(ArchiveStatus::InProgress);
     let ipfs_status = if !ipfs_needed {
-        "done"
+        IpfsStatus::Done
     } else {
-        meta.ipfs_status.as_deref().unwrap_or("in_progress")
+        meta.ipfs_status.unwrap_or(IpfsStatus::InProgress)
     };
-    (archive_needed && archive_status == "in_progress")
-        || (ipfs_needed && ipfs_status == "in_progress")
+    (archive_needed && archive_status == ArchiveStatus::InProgress)
+        || (ipfs_needed && ipfs_status == IpfsStatus::InProgress)
 }
 
 /// Validate if a task is in the process of deletion for the given scope/storage mode.
@@ -187,13 +188,13 @@ async fn handle_backup_retries_core<DB: Database + ?Sized>(
 mod handle_backup_retries_core_tests {
     use super::handle_backup_retries_core;
     use crate::server::database::r#trait::MockDatabase;
-    use crate::server::database::BackupTask;
+    use crate::server::database::{ArchiveStatus, BackupTask};
     use crate::server::StorageMode;
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
     use tokio::sync::mpsc;
 
-    fn sample_meta(owner: &str, status: &str) -> BackupTask {
+    fn sample_meta(owner: &str, status: ArchiveStatus) -> BackupTask {
         use chrono::{TimeZone, Utc};
         BackupTask {
             task_id: "t1".to_string(),
@@ -202,7 +203,7 @@ mod handle_backup_retries_core_tests {
             requestor: owner.to_string(),
             nft_count: 1,
             tokens: serde_json::json!([{"chain":"ethereum","tokens":["0xabc:1"]}]),
-            archive_status: Some(status.to_string()),
+            archive_status: Some(status),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,
@@ -241,7 +242,7 @@ mod handle_backup_retries_core_tests {
     #[tokio::test]
     async fn returns_409_when_in_progress() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "in_progress")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::InProgress)));
         let (tx, _rx) = mpsc::channel(1);
         let resp = handle_backup_retries_core(&db, &tx, "t1", None, Some("did:me".to_string()), 7)
             .await
@@ -251,7 +252,7 @@ mod handle_backup_retries_core_tests {
 
     #[tokio::test]
     async fn returns_409_when_being_deleted() {
-        let mut meta = sample_meta("did:me", "done");
+        let mut meta = sample_meta("did:me", ArchiveStatus::Done);
         meta.archive_deleted_at = Some(chrono::Utc::now());
         let mut db = MockDatabase::default();
         db.set_get_backup_task_result(Some(meta));
@@ -265,7 +266,7 @@ mod handle_backup_retries_core_tests {
     #[tokio::test]
     async fn returns_403_on_owner_mismatch() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:other", "done")));
+        db.set_get_backup_task_result(Some(sample_meta("did:other", ArchiveStatus::Done)));
         let (tx, _rx) = mpsc::channel(1);
         let resp = handle_backup_retries_core(&db, &tx, "t1", None, Some("did:me".to_string()), 7)
             .await
@@ -276,7 +277,7 @@ mod handle_backup_retries_core_tests {
     #[tokio::test]
     async fn returns_500_when_enqueue_fails() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "done")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Done)));
         let (tx, rx) = mpsc::channel(1);
         drop(rx); // close receiver to force send error
         let resp = handle_backup_retries_core(&db, &tx, "t1", None, Some("did:me".to_string()), 7)
@@ -288,7 +289,7 @@ mod handle_backup_retries_core_tests {
     #[tokio::test]
     async fn returns_202_on_success_with_scope() {
         let mut db = MockDatabase::default();
-        db.set_get_backup_task_result(Some(sample_meta("did:me", "error")));
+        db.set_get_backup_task_result(Some(sample_meta("did:me", ArchiveStatus::Error)));
         let (tx, mut rx) = mpsc::channel(1);
         let resp = handle_backup_retries_core(
             &db,
@@ -311,10 +312,17 @@ mod handle_backup_retries_core_tests {
 mod validate_scope_for_retry_tests {
     use super::validate_scope_for_retry;
     use crate::server::database::BackupTask;
+    use crate::server::database::{ArchiveStatus, IpfsStatus};
     use crate::server::StorageMode;
 
-    fn sample_meta(owner: &str, status: &str, storage_mode: &str) -> BackupTask {
+    fn sample_meta(owner: &str, status: ArchiveStatus, storage_mode: &str) -> BackupTask {
         use chrono::{TimeZone, Utc};
+        let ipfs_status = match status {
+            ArchiveStatus::InProgress => IpfsStatus::InProgress,
+            ArchiveStatus::Done => IpfsStatus::Done,
+            ArchiveStatus::Error => IpfsStatus::Error,
+            ArchiveStatus::Expired => IpfsStatus::Done,
+        };
         BackupTask {
             task_id: "t1".to_string(),
             created_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
@@ -322,8 +330,8 @@ mod validate_scope_for_retry_tests {
             requestor: owner.to_string(),
             nft_count: 1,
             tokens: serde_json::json!([["ethereum", "0xabc:1"]]),
-            archive_status: Some(status.to_string()),
-            ipfs_status: Some(status.to_string()),
+            archive_status: Some(status),
+            ipfs_status: Some(ipfs_status),
             archive_error_log: None,
             ipfs_error_log: None,
             archive_fatal_error: None,
@@ -338,21 +346,21 @@ mod validate_scope_for_retry_tests {
 
     #[test]
     fn archive_scope_conflicts_when_archive_in_progress() {
-        let meta = sample_meta("did:me", "in_progress", "full");
+        let meta = sample_meta("did:me", ArchiveStatus::InProgress, "full");
         let conflict = validate_scope_for_retry(&meta, StorageMode::Archive);
         assert!(conflict);
     }
 
     #[test]
     fn ipfs_scope_conflicts_when_ipfs_in_progress() {
-        let meta = sample_meta("did:me", "in_progress", "full");
+        let meta = sample_meta("did:me", ArchiveStatus::InProgress, "full");
         let conflict = validate_scope_for_retry(&meta, StorageMode::Ipfs);
         assert!(conflict);
     }
 
     #[test]
     fn full_scope_conflicts_when_either_in_progress() {
-        let meta = sample_meta("did:me", "in_progress", "full");
+        let meta = sample_meta("did:me", ArchiveStatus::InProgress, "full");
         let conflict = validate_scope_for_retry(&meta, StorageMode::Full);
         assert!(conflict);
     }

--- a/src/server/handlers/handle_backup_retries.rs
+++ b/src/server/handlers/handle_backup_retries.rs
@@ -28,14 +28,16 @@ fn validate_scope_for_retry(
         StorageMode::Ipfs => (false, true),
         StorageMode::Full => (true, true),
     };
-    let archive_status = meta.archive_status.unwrap_or(ArchiveStatus::InProgress);
-    let ipfs_status = if !ipfs_needed {
-        IpfsStatus::Done
-    } else {
-        meta.ipfs_status.unwrap_or(IpfsStatus::InProgress)
-    };
-    (archive_needed && archive_status == ArchiveStatus::InProgress)
-        || (ipfs_needed && ipfs_status == IpfsStatus::InProgress)
+    // A missing status is treated as in_progress.
+    let archive_in_progress = meta
+        .archive_status
+        .as_ref()
+        .is_none_or(|s| *s == ArchiveStatus::InProgress);
+    let ipfs_in_progress = meta
+        .ipfs_status
+        .as_ref()
+        .is_none_or(|s| *s == IpfsStatus::InProgress);
+    (archive_needed && archive_in_progress) || (ipfs_needed && ipfs_in_progress)
 }
 
 /// Validate if a task is in the process of deletion for the given scope/storage mode.

--- a/src/server/handlers/handle_backups.rs
+++ b/src/server/handlers/handle_backups.rs
@@ -152,6 +152,7 @@ async fn handle_backups_core<DB: Database + ?Sized>(
 mod handle_backups_core_mockdb_tests {
     use super::handle_backups_core;
     use crate::server::database::r#trait::MockDatabase;
+    use crate::server::database::ArchiveStatus;
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
 
@@ -182,7 +183,7 @@ mod handle_backups_core_mockdb_tests {
                 requestor: "did:privy:alice".to_string(),
                 nft_count: 1,
                 tokens: serde_json::json!([]),
-                archive_status: Some("done".to_string()),
+                archive_status: Some(ArchiveStatus::Done),
                 ipfs_status: None,
                 archive_error_log: None,
                 ipfs_error_log: None,

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -73,6 +73,7 @@ pub async fn verify_requestor_owns_task<DB: Database + ?Sized>(
 mod verify_owns_task_tests {
     use super::verify_requestor_owns_task;
     use crate::server::database::r#trait::MockDatabase;
+    use crate::server::database::ArchiveStatus;
     use crate::server::database::BackupTask;
     use axum::http::StatusCode;
     use chrono::{TimeZone, Utc};
@@ -85,7 +86,7 @@ mod verify_owns_task_tests {
             requestor: req.to_string(),
             nft_count: 1,
             tokens: serde_json::json!([]),
-            archive_status: Some("done".to_string()),
+            archive_status: Some(ArchiveStatus::Done),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,

--- a/src/server/pin_monitor.rs
+++ b/src/server/pin_monitor.rs
@@ -4,7 +4,7 @@ use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration as TokioDuration};
 use tracing::{error, info, warn};
 
-use crate::ipfs::{IpfsPinningProvider, PinResponseStatus};
+use crate::ipfs::IpfsPinningProvider;
 use crate::server::database::{r#trait::Database, Db};
 
 /// Monitor and update the status of queued or pinning pin requests
@@ -45,7 +45,7 @@ pub async fn monitor_pin_requests<DB: Database + ?Sized>(
                 // Only update if the status has changed
                 if new_status != &pin.pin_status {
                     let new_status_str = serde_json::to_value(new_status)
-                        .and_then(|v| Ok(v.as_str().unwrap().to_string()))
+                        .map(|v| v.as_str().unwrap().to_string())
                         .unwrap_or_default();
                     status_updates.push((pin.id, new_status_str));
                     info!(
@@ -201,7 +201,12 @@ mod tests {
         }
     }
 
-    fn create_test_pin_row(id: i64, provider_url: &str, request_id: &str, status: PinResponseStatus) -> PinRow {
+    fn create_test_pin_row(
+        id: i64,
+        provider_url: &str,
+        request_id: &str,
+        status: PinResponseStatus,
+    ) -> PinRow {
         PinRow {
             id,
             task_id: "test-task".to_string(),
@@ -267,7 +272,8 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_no_provider_found() {
         // Setup: DB has a pin request for a provider that doesn't exist
-        let pin_request = create_test_pin_row(1, "unknown-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request =
+            create_test_pin_row(1, "unknown-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -286,7 +292,8 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_provider_name_mismatch() {
         // Setup: DB has a pin request for a provider that doesn't match any configured providers
-        let pin_request = create_test_pin_row(1, "unknown-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request =
+            create_test_pin_row(1, "unknown-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -317,7 +324,8 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_provider_error() {
         // Setup: DB has a pin request for a valid provider
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request =
+            create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -342,7 +350,8 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_status_unchanged() {
         // Setup: DB has a pin request with queued status
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request =
+            create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -370,7 +379,8 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_status_changed() {
         // Setup: DB has a pin request with queued status
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request =
+            create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -398,8 +408,10 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_multiple_status_changes() {
         // Setup: DB has 2 pin requests with different initial statuses
-        let pin_request1 = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
-        let pin_request2 = create_test_pin_row(2, "test-provider", "req-2", PinResponseStatus::Pinning);
+        let pin_request1 =
+            create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request2 =
+            create_test_pin_row(2, "test-provider", "req-2", PinResponseStatus::Pinning);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request1, pin_request2]);
 
@@ -428,7 +440,8 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_batch_update_error() {
         // Setup: DB has a pin request and will fail on batch update
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request =
+            create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
         mock_db.set_update_pin_statuses_error(Some("Batch update error".to_string()));
@@ -458,7 +471,8 @@ mod tests {
     async fn test_monitor_pin_requests_mixed_providers() {
         // Setup: DB has 2 pin requests for different providers
         let pin_request1 = create_test_pin_row(1, "provider-1", "req-1", PinResponseStatus::Queued);
-        let pin_request2 = create_test_pin_row(2, "provider-2", "req-2", PinResponseStatus::Pinning);
+        let pin_request2 =
+            create_test_pin_row(2, "provider-2", "req-2", PinResponseStatus::Pinning);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request1, pin_request2]);
 
@@ -499,7 +513,8 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_queued_to_pinned_transition() {
         // Setup: DB has a queued pin request
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request =
+            create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -527,10 +542,14 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_all_status_types() {
         // Setup: DB has 4 pin requests with different initial statuses
-        let pin_request1 = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
-        let pin_request2 = create_test_pin_row(2, "test-provider", "req-2", PinResponseStatus::Pinning);
-        let pin_request3 = create_test_pin_row(3, "test-provider", "req-3", PinResponseStatus::Pinned);
-        let pin_request4 = create_test_pin_row(4, "test-provider", "req-4", PinResponseStatus::Failed);
+        let pin_request1 =
+            create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request2 =
+            create_test_pin_row(2, "test-provider", "req-2", PinResponseStatus::Pinning);
+        let pin_request3 =
+            create_test_pin_row(3, "test-provider", "req-3", PinResponseStatus::Pinned);
+        let pin_request4 =
+            create_test_pin_row(4, "test-provider", "req-4", PinResponseStatus::Failed);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![
             pin_request1,

--- a/src/server/pin_monitor.rs
+++ b/src/server/pin_monitor.rs
@@ -44,10 +44,7 @@ pub async fn monitor_pin_requests<DB: Database + ?Sized>(
 
                 // Only update if the status has changed
                 if new_status != &pin.pin_status {
-                    let new_status_str = serde_json::to_value(new_status)
-                        .map(|v| v.as_str().unwrap().to_string())
-                        .unwrap_or_default();
-                    status_updates.push((pin.id, new_status_str));
+                    status_updates.push((pin.id, new_status.as_str().to_string()));
                     info!(
                         "Queued status update for pin {}: {:?} -> {:?}",
                         pin.id, pin.pin_status, new_status

--- a/src/server/pin_monitor.rs
+++ b/src/server/pin_monitor.rs
@@ -40,18 +40,16 @@ pub async fn monitor_pin_requests<DB: Database + ?Sized>(
         // Get the current status from the provider
         match provider.get_pin(&pin.request_id).await {
             Ok(pin_response) => {
-                let new_status = match pin_response.status {
-                    PinResponseStatus::Queued => "queued",
-                    PinResponseStatus::Pinning => "pinning",
-                    PinResponseStatus::Pinned => "pinned",
-                    PinResponseStatus::Failed => "failed",
-                };
+                let new_status = &pin_response.status;
 
                 // Only update if the status has changed
-                if new_status != pin.pin_status {
-                    status_updates.push((pin.id, new_status.to_string()));
+                if new_status != &pin.pin_status {
+                    let new_status_str = serde_json::to_value(new_status)
+                        .and_then(|v| Ok(v.as_str().unwrap().to_string()))
+                        .unwrap_or_default();
+                    status_updates.push((pin.id, new_status_str));
                     info!(
-                        "Queued status update for pin {}: {} -> {}",
+                        "Queued status update for pin {}: {:?} -> {:?}",
                         pin.id, pin.pin_status, new_status
                     );
                 }
@@ -203,7 +201,7 @@ mod tests {
         }
     }
 
-    fn create_test_pin_row(id: i64, provider_url: &str, request_id: &str, status: &str) -> PinRow {
+    fn create_test_pin_row(id: i64, provider_url: &str, request_id: &str, status: PinResponseStatus) -> PinRow {
         PinRow {
             id,
             task_id: "test-task".to_string(),
@@ -211,7 +209,7 @@ mod tests {
             provider_url: Some(provider_url.to_string()),
             cid: "QmTestCid".to_string(),
             request_id: request_id.to_string(),
-            pin_status: status.to_string(),
+            pin_status: status,
             created_at: chrono::Utc::now(),
         }
     }
@@ -269,7 +267,7 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_no_provider_found() {
         // Setup: DB has a pin request for a provider that doesn't exist
-        let pin_request = create_test_pin_row(1, "unknown-provider", "req-1", "queued");
+        let pin_request = create_test_pin_row(1, "unknown-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -288,7 +286,7 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_provider_name_mismatch() {
         // Setup: DB has a pin request for a provider that doesn't match any configured providers
-        let pin_request = create_test_pin_row(1, "unknown-provider", "req-1", "queued");
+        let pin_request = create_test_pin_row(1, "unknown-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -319,7 +317,7 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_provider_error() {
         // Setup: DB has a pin request for a valid provider
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", "queued");
+        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -344,7 +342,7 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_status_unchanged() {
         // Setup: DB has a pin request with queued status
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", "queued");
+        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -372,7 +370,7 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_status_changed() {
         // Setup: DB has a pin request with queued status
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", "queued");
+        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -400,8 +398,8 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_multiple_status_changes() {
         // Setup: DB has 2 pin requests with different initial statuses
-        let pin_request1 = create_test_pin_row(1, "test-provider", "req-1", "queued");
-        let pin_request2 = create_test_pin_row(2, "test-provider", "req-2", "pinning");
+        let pin_request1 = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request2 = create_test_pin_row(2, "test-provider", "req-2", PinResponseStatus::Pinning);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request1, pin_request2]);
 
@@ -430,7 +428,7 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_batch_update_error() {
         // Setup: DB has a pin request and will fail on batch update
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", "queued");
+        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
         mock_db.set_update_pin_statuses_error(Some("Batch update error".to_string()));
@@ -459,8 +457,8 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_mixed_providers() {
         // Setup: DB has 2 pin requests for different providers
-        let pin_request1 = create_test_pin_row(1, "provider-1", "req-1", "queued");
-        let pin_request2 = create_test_pin_row(2, "provider-2", "req-2", "pinning");
+        let pin_request1 = create_test_pin_row(1, "provider-1", "req-1", PinResponseStatus::Queued);
+        let pin_request2 = create_test_pin_row(2, "provider-2", "req-2", PinResponseStatus::Pinning);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request1, pin_request2]);
 
@@ -501,7 +499,7 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_queued_to_pinned_transition() {
         // Setup: DB has a queued pin request
-        let pin_request = create_test_pin_row(1, "test-provider", "req-1", "queued");
+        let pin_request = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![pin_request]);
 
@@ -529,10 +527,10 @@ mod tests {
     #[tokio::test]
     async fn test_monitor_pin_requests_all_status_types() {
         // Setup: DB has 4 pin requests with different initial statuses
-        let pin_request1 = create_test_pin_row(1, "test-provider", "req-1", "queued");
-        let pin_request2 = create_test_pin_row(2, "test-provider", "req-2", "pinning");
-        let pin_request3 = create_test_pin_row(3, "test-provider", "req-3", "pinned");
-        let pin_request4 = create_test_pin_row(4, "test-provider", "req-4", "failed");
+        let pin_request1 = create_test_pin_row(1, "test-provider", "req-1", PinResponseStatus::Queued);
+        let pin_request2 = create_test_pin_row(2, "test-provider", "req-2", PinResponseStatus::Pinning);
+        let pin_request3 = create_test_pin_row(3, "test-provider", "req-3", PinResponseStatus::Pinned);
+        let pin_request4 = create_test_pin_row(4, "test-provider", "req-4", PinResponseStatus::Failed);
         let mut mock_db = MockDatabase::default();
         mock_db.set_get_active_pins_result(vec![
             pin_request1,

--- a/src/server/pruner.rs
+++ b/src/server/pruner.rs
@@ -6,7 +6,7 @@ use tokio::time::{sleep, Duration as TokioDuration};
 use tracing::{info, warn};
 
 use crate::server::archive::get_zipped_backup_paths;
-use crate::server::database::{r#trait::Database, Db, ExpiredBackup};
+use crate::server::database::{r#trait::Database, ArchiveStatus, Db, ExpiredBackup};
 
 async fn prune_backups<DB: Database + ?Sized>(db: &DB, base_dir: &str, expired: &[ExpiredBackup]) {
     let mut pruned_task_ids = Vec::new();
@@ -26,7 +26,7 @@ async fn prune_backups<DB: Database + ?Sized>(db: &DB, base_dir: &str, expired: 
     }
     if !pruned_task_ids.is_empty() {
         if let Err(e) = db
-            .update_archive_request_statuses(&pruned_task_ids, "expired")
+            .update_archive_request_statuses(&pruned_task_ids, &ArchiveStatus::Expired)
             .await
         {
             warn!("Failed to update status for pruned backups: {}", e);

--- a/src/server/recovery/mod.rs
+++ b/src/server/recovery/mod.rs
@@ -91,6 +91,7 @@ mod tests {
     use super::*;
     use crate::server::database::r#trait::MockDatabase;
     use crate::server::database::BackupTask as DbBackupTask;
+    use crate::server::database::{ArchiveStatus, IpfsStatus};
     use chrono::Utc;
     use serde_json::json;
     use tokio::sync::mpsc;
@@ -117,7 +118,7 @@ mod tests {
                 requestor: "user1".to_string(),
                 nft_count: 0,
                 tokens: json!([{ "chain": "ethereum", "tokens": ["0x123"] }]),
-                archive_status: Some("in_progress".to_string()),
+                archive_status: Some(ArchiveStatus::InProgress),
                 ipfs_status: None,
                 archive_error_log: None,
                 ipfs_error_log: None,
@@ -136,8 +137,8 @@ mod tests {
                 requestor: "user2".to_string(),
                 nft_count: 0,
                 tokens: json!([{ "chain": "tezos", "tokens": ["KT1ABC"] }]),
-                archive_status: Some("in_progress".to_string()),
-                ipfs_status: Some("in_progress".to_string()),
+                archive_status: Some(ArchiveStatus::InProgress),
+                ipfs_status: Some(IpfsStatus::InProgress),
                 archive_error_log: None,
                 ipfs_error_log: None,
                 archive_fatal_error: None,
@@ -194,7 +195,7 @@ mod tests {
             requestor: "user1".to_string(),
             nft_count: 0,
             tokens: json!("invalid tokens"),
-            archive_status: Some("in_progress".to_string()),
+            archive_status: Some(ArchiveStatus::InProgress),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,
@@ -239,7 +240,7 @@ mod tests {
             requestor: "user1".to_string(),
             nft_count: 0,
             tokens: json!([{ "chain": "ethereum", "tokens": ["0x123"] }]),
-            archive_status: Some("in_progress".to_string()),
+            archive_status: Some(ArchiveStatus::InProgress),
             ipfs_status: None,
             archive_error_log: None,
             ipfs_error_log: None,

--- a/src/server/workers/creation.rs
+++ b/src/server/workers/creation.rs
@@ -9,6 +9,7 @@ use crate::server::archive::{
     get_zipped_backup_paths, sync_files, zip_backup, ARCHIVE_INTERRUPTED_BY_SHUTDOWN,
 };
 use crate::server::database::r#trait::Database;
+use crate::server::database::{ArchiveStatus, IpfsStatus};
 use crate::server::{AppState, BackupTask, StorageMode};
 use crate::{BackupConfig, IpfsOutcome, ProcessManagementConfig, StorageConfig, TokenConfig};
 
@@ -276,7 +277,7 @@ async fn run_backup_task_inner<DB: Database + ?Sized>(state: AppState, task: Bac
     match scope {
         StorageMode::Ipfs => {
             let success = process_ipfs_outcome(db, &task, &ipfs_outcome).await;
-            let status = if success { "done" } else { "error" };
+            let status = if success { &IpfsStatus::Done } else { &IpfsStatus::Error };
             let _ = db.update_pin_request_status(&task_id, status).await;
         }
         StorageMode::Archive => {
@@ -295,10 +296,10 @@ async fn run_backup_task_inner<DB: Database + ?Sized>(state: AppState, task: Bac
             .await;
             match result {
                 ArchiveResult::Success => {
-                    let _ = db.update_archive_request_status(&task_id, "done").await;
+                    let _ = db.update_archive_request_status(&task_id, &ArchiveStatus::Done).await;
                 }
                 ArchiveResult::Error => {
-                    let _ = db.update_archive_request_status(&task_id, "error").await;
+                    let _ = db.update_archive_request_status(&task_id, &ArchiveStatus::Error).await;
                 }
                 ArchiveResult::ShutdownInterrupted => {
                     // Don't update status; leave it as is (likely "in_progress")
@@ -329,11 +330,11 @@ async fn run_backup_task_inner<DB: Database + ?Sized>(state: AppState, task: Bac
                 .await;
                 match result {
                     ArchiveResult::Success => {
-                        let _ = db.update_archive_request_status(&task_id_ref, "done").await;
+                        let _ = db.update_archive_request_status(&task_id_ref, &ArchiveStatus::Done).await;
                     }
                     ArchiveResult::Error => {
                         let _ = db
-                            .update_archive_request_status(&task_id_ref, "error")
+                            .update_archive_request_status(&task_id_ref, &ArchiveStatus::Error)
                             .await;
                     }
                     ArchiveResult::ShutdownInterrupted => {
@@ -344,7 +345,7 @@ async fn run_backup_task_inner<DB: Database + ?Sized>(state: AppState, task: Bac
 
             let ipfs_fut = async {
                 let success = process_ipfs_outcome(db, &task, &ipfs_outcome).await;
-                let status = if success { "done" } else { "error" };
+                let status = if success { &IpfsStatus::Done } else { &IpfsStatus::Error };
                 let _ = db.update_pin_request_status(&task_id, status).await;
             };
 

--- a/src/server/workers/creation.rs
+++ b/src/server/workers/creation.rs
@@ -277,7 +277,11 @@ async fn run_backup_task_inner<DB: Database + ?Sized>(state: AppState, task: Bac
     match scope {
         StorageMode::Ipfs => {
             let success = process_ipfs_outcome(db, &task, &ipfs_outcome).await;
-            let status = if success { &IpfsStatus::Done } else { &IpfsStatus::Error };
+            let status = if success {
+                &IpfsStatus::Done
+            } else {
+                &IpfsStatus::Error
+            };
             let _ = db.update_pin_request_status(&task_id, status).await;
         }
         StorageMode::Archive => {
@@ -296,10 +300,14 @@ async fn run_backup_task_inner<DB: Database + ?Sized>(state: AppState, task: Bac
             .await;
             match result {
                 ArchiveResult::Success => {
-                    let _ = db.update_archive_request_status(&task_id, &ArchiveStatus::Done).await;
+                    let _ = db
+                        .update_archive_request_status(&task_id, &ArchiveStatus::Done)
+                        .await;
                 }
                 ArchiveResult::Error => {
-                    let _ = db.update_archive_request_status(&task_id, &ArchiveStatus::Error).await;
+                    let _ = db
+                        .update_archive_request_status(&task_id, &ArchiveStatus::Error)
+                        .await;
                 }
                 ArchiveResult::ShutdownInterrupted => {
                     // Don't update status; leave it as is (likely "in_progress")
@@ -330,7 +338,9 @@ async fn run_backup_task_inner<DB: Database + ?Sized>(state: AppState, task: Bac
                 .await;
                 match result {
                     ArchiveResult::Success => {
-                        let _ = db.update_archive_request_status(&task_id_ref, &ArchiveStatus::Done).await;
+                        let _ = db
+                            .update_archive_request_status(&task_id_ref, &ArchiveStatus::Done)
+                            .await;
                     }
                     ArchiveResult::Error => {
                         let _ = db
@@ -345,7 +355,11 @@ async fn run_backup_task_inner<DB: Database + ?Sized>(state: AppState, task: Bac
 
             let ipfs_fut = async {
                 let success = process_ipfs_outcome(db, &task, &ipfs_outcome).await;
-                let status = if success { &IpfsStatus::Done } else { &IpfsStatus::Error };
+                let status = if success {
+                    &IpfsStatus::Done
+                } else {
+                    &IpfsStatus::Error
+                };
                 let _ = db.update_pin_request_status(&task_id, status).await;
             };
 

--- a/src/server/workers/deletion.rs
+++ b/src/server/workers/deletion.rs
@@ -329,31 +329,61 @@ pub async fn run_deletion_task(state: AppState, task: DeletionTask) {
 
 #[cfg(test)]
 mod validate_status_for_scope_tests {
-    use super::{validate_status_for_scope, StorageMode, ArchiveStatus, IpfsStatus};
+    use super::{validate_status_for_scope, ArchiveStatus, IpfsStatus, StorageMode};
 
     #[test]
     fn table_validates_all_cases() {
         // (scope, archive_status, ipfs_status, expect_ok)
-        let cases: Vec<(
-            StorageMode,
-            Option<ArchiveStatus>,
-            Option<IpfsStatus>,
-            bool,
-        )> = vec![
+        let cases: Vec<(StorageMode, Option<ArchiveStatus>, Option<IpfsStatus>, bool)> = vec![
             // Full scope
-            (StorageMode::Full, Some(ArchiveStatus::Done), Some(IpfsStatus::Done), true),
-            (StorageMode::Full, Some(ArchiveStatus::Error), Some(IpfsStatus::Done), true),
+            (
+                StorageMode::Full,
+                Some(ArchiveStatus::Done),
+                Some(IpfsStatus::Done),
+                true,
+            ),
+            (
+                StorageMode::Full,
+                Some(ArchiveStatus::Error),
+                Some(IpfsStatus::Done),
+                true,
+            ),
             (StorageMode::Full, None, Some(IpfsStatus::Done), true),
             (StorageMode::Full, Some(ArchiveStatus::Done), None, true),
             (StorageMode::Full, None, None, true),
-            (StorageMode::Full, Some(ArchiveStatus::InProgress), Some(IpfsStatus::Done), false),
-            (StorageMode::Full, Some(ArchiveStatus::Done), Some(IpfsStatus::InProgress), false),
-            (StorageMode::Full, Some(ArchiveStatus::InProgress), None, false),
+            (
+                StorageMode::Full,
+                Some(ArchiveStatus::InProgress),
+                Some(IpfsStatus::Done),
+                false,
+            ),
+            (
+                StorageMode::Full,
+                Some(ArchiveStatus::Done),
+                Some(IpfsStatus::InProgress),
+                false,
+            ),
+            (
+                StorageMode::Full,
+                Some(ArchiveStatus::InProgress),
+                None,
+                false,
+            ),
             (StorageMode::Full, None, Some(IpfsStatus::InProgress), false),
             // Archive scope
-            (StorageMode::Archive, Some(ArchiveStatus::Done), Some(IpfsStatus::Done), true),
+            (
+                StorageMode::Archive,
+                Some(ArchiveStatus::Done),
+                Some(IpfsStatus::Done),
+                true,
+            ),
             (StorageMode::Archive, Some(ArchiveStatus::Error), None, true),
-            (StorageMode::Archive, None, Some(IpfsStatus::InProgress), true),
+            (
+                StorageMode::Archive,
+                None,
+                Some(IpfsStatus::InProgress),
+                true,
+            ),
             (StorageMode::Archive, None, None, true),
             (
                 StorageMode::Archive,
@@ -361,18 +391,38 @@ mod validate_status_for_scope_tests {
                 Some(IpfsStatus::Done),
                 false,
             ),
-            (StorageMode::Archive, Some(ArchiveStatus::InProgress), None, false),
+            (
+                StorageMode::Archive,
+                Some(ArchiveStatus::InProgress),
+                None,
+                false,
+            ),
             // Ipfs scope
-            (StorageMode::Ipfs, Some(ArchiveStatus::Done), Some(IpfsStatus::Done), true),
+            (
+                StorageMode::Ipfs,
+                Some(ArchiveStatus::Done),
+                Some(IpfsStatus::Done),
+                true,
+            ),
             (StorageMode::Ipfs, None, Some(IpfsStatus::Error), true),
-            (StorageMode::Ipfs, Some(ArchiveStatus::InProgress), None, true),
+            (
+                StorageMode::Ipfs,
+                Some(ArchiveStatus::InProgress),
+                None,
+                true,
+            ),
             (StorageMode::Ipfs, None, None, true),
-            (StorageMode::Ipfs, Some(ArchiveStatus::Done), Some(IpfsStatus::InProgress), false),
+            (
+                StorageMode::Ipfs,
+                Some(ArchiveStatus::Done),
+                Some(IpfsStatus::InProgress),
+                false,
+            ),
             (StorageMode::Ipfs, None, Some(IpfsStatus::InProgress), false),
         ];
 
         for (idx, (scope, a, i, expect_ok)) in cases.into_iter().enumerate() {
-            let result = validate_status_for_scope(&scope, a, i);
+            let result = validate_status_for_scope(&scope, a.as_ref(), i.as_ref());
             let ok = result.is_ok();
             assert_eq!(
                 ok, expect_ok,
@@ -386,6 +436,7 @@ mod validate_status_for_scope_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ipfs::PinResponseStatus;
 
     #[tokio::test]
     async fn delete_dir_and_archive_for_task_removes_files_and_dir() {
@@ -491,7 +542,7 @@ mod tests {
                 provider_url: Some("mock".into()),
                 cid: "cid1".into(),
                 request_id: "rid1".into(),
-                pin_status: "pinned".into(),
+                pin_status: PinResponseStatus::Pinned,
                 created_at: chrono::Utc::now(),
             },
             crate::server::database::PinRow {
@@ -501,7 +552,7 @@ mod tests {
                 provider_url: Some("mock".into()),
                 cid: "cid2".into(),
                 request_id: "rid2".into(),
-                pin_status: "pinned".into(),
+                pin_status: PinResponseStatus::Pinned,
                 created_at: chrono::Utc::now(),
             },
         ];
@@ -522,7 +573,7 @@ mod tests {
             provider_url: Some("https://unknown".into()),
             cid: "cid".into(),
             request_id: "rid".into(),
-            pin_status: "pinned".into(),
+            pin_status: PinResponseStatus::Pinned,
             created_at: chrono::Utc::now(),
         }];
         let result = delete_ipfs_pins(&providers, "t", &rows).await.unwrap();

--- a/src/server/workers/deletion.rs
+++ b/src/server/workers/deletion.rs
@@ -2,16 +2,16 @@ use futures_util::FutureExt;
 use std::panic::AssertUnwindSafe;
 use tracing::{debug, error, info};
 
-use crate::server::database::r#trait::Database;
+use crate::server::database::{r#trait::Database, ArchiveStatus, IpfsStatus};
 use crate::server::{AppState, DeletionTask, StorageMode};
 
 pub fn validate_status_for_scope(
     scope: &StorageMode,
-    archive_status: Option<&str>,
-    ipfs_status: Option<&str>,
+    archive_status: Option<&ArchiveStatus>,
+    ipfs_status: Option<&IpfsStatus>,
 ) -> Result<(), &'static str> {
-    let a_in_progress = matches!(archive_status, Some("in_progress"));
-    let i_in_progress = matches!(ipfs_status, Some("in_progress"));
+    let a_in_progress = matches!(archive_status, Some(ArchiveStatus::InProgress));
+    let i_in_progress = matches!(ipfs_status, Some(IpfsStatus::InProgress));
     match scope {
         StorageMode::Archive => {
             if a_in_progress {
@@ -221,8 +221,8 @@ async fn run_deletion_task_inner<DB: Database + ?Sized>(
     // Check if task is in progress for the requested scope
     if validate_status_for_scope(
         &task.scope,
-        meta.archive_status.as_deref(),
-        meta.ipfs_status.as_deref(),
+        meta.archive_status.as_ref(),
+        meta.ipfs_status.as_ref(),
     )
     .is_err()
     {
@@ -329,46 +329,46 @@ pub async fn run_deletion_task(state: AppState, task: DeletionTask) {
 
 #[cfg(test)]
 mod validate_status_for_scope_tests {
-    use super::{validate_status_for_scope, StorageMode};
+    use super::{validate_status_for_scope, StorageMode, ArchiveStatus, IpfsStatus};
 
     #[test]
     fn table_validates_all_cases() {
         // (scope, archive_status, ipfs_status, expect_ok)
         let cases: Vec<(
             StorageMode,
-            Option<&'static str>,
-            Option<&'static str>,
+            Option<ArchiveStatus>,
+            Option<IpfsStatus>,
             bool,
         )> = vec![
             // Full scope
-            (StorageMode::Full, Some("done"), Some("done"), true),
-            (StorageMode::Full, Some("error"), Some("done"), true),
-            (StorageMode::Full, None, Some("done"), true),
-            (StorageMode::Full, Some("done"), None, true),
+            (StorageMode::Full, Some(ArchiveStatus::Done), Some(IpfsStatus::Done), true),
+            (StorageMode::Full, Some(ArchiveStatus::Error), Some(IpfsStatus::Done), true),
+            (StorageMode::Full, None, Some(IpfsStatus::Done), true),
+            (StorageMode::Full, Some(ArchiveStatus::Done), None, true),
             (StorageMode::Full, None, None, true),
-            (StorageMode::Full, Some("in_progress"), Some("done"), false),
-            (StorageMode::Full, Some("done"), Some("in_progress"), false),
-            (StorageMode::Full, Some("in_progress"), None, false),
-            (StorageMode::Full, None, Some("in_progress"), false),
+            (StorageMode::Full, Some(ArchiveStatus::InProgress), Some(IpfsStatus::Done), false),
+            (StorageMode::Full, Some(ArchiveStatus::Done), Some(IpfsStatus::InProgress), false),
+            (StorageMode::Full, Some(ArchiveStatus::InProgress), None, false),
+            (StorageMode::Full, None, Some(IpfsStatus::InProgress), false),
             // Archive scope
-            (StorageMode::Archive, Some("done"), Some("done"), true),
-            (StorageMode::Archive, Some("error"), None, true),
-            (StorageMode::Archive, None, Some("in_progress"), true),
+            (StorageMode::Archive, Some(ArchiveStatus::Done), Some(IpfsStatus::Done), true),
+            (StorageMode::Archive, Some(ArchiveStatus::Error), None, true),
+            (StorageMode::Archive, None, Some(IpfsStatus::InProgress), true),
             (StorageMode::Archive, None, None, true),
             (
                 StorageMode::Archive,
-                Some("in_progress"),
-                Some("done"),
+                Some(ArchiveStatus::InProgress),
+                Some(IpfsStatus::Done),
                 false,
             ),
-            (StorageMode::Archive, Some("in_progress"), None, false),
+            (StorageMode::Archive, Some(ArchiveStatus::InProgress), None, false),
             // Ipfs scope
-            (StorageMode::Ipfs, Some("done"), Some("done"), true),
-            (StorageMode::Ipfs, None, Some("error"), true),
-            (StorageMode::Ipfs, Some("in_progress"), None, true),
+            (StorageMode::Ipfs, Some(ArchiveStatus::Done), Some(IpfsStatus::Done), true),
+            (StorageMode::Ipfs, None, Some(IpfsStatus::Error), true),
+            (StorageMode::Ipfs, Some(ArchiveStatus::InProgress), None, true),
             (StorageMode::Ipfs, None, None, true),
-            (StorageMode::Ipfs, Some("done"), Some("in_progress"), false),
-            (StorageMode::Ipfs, None, Some("in_progress"), false),
+            (StorageMode::Ipfs, Some(ArchiveStatus::Done), Some(IpfsStatus::InProgress), false),
+            (StorageMode::Ipfs, None, Some(IpfsStatus::InProgress), false),
         ];
 
         for (idx, (scope, a, i, expect_ok)) in cases.into_iter().enumerate() {


### PR DESCRIPTION
Define ArchiveStatus and IpfsStatus enums with serde snake_case serialization (matching existing DB string values). Update BackupTask, PinRow, Database trait, Db impl, workers, handlers, recovery module, pruner, pin monitor, CLI, and all tests to use the new types instead of raw strings.

No DB migration needed — enum serde produces the same strings:
- ArchiveStatus: in_progress, done, error, expired
- IpfsStatus: in_progress, done, error
- PinRow.pin_status uses existing PinResponseStatus enum

Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Status handling for backup archive and IPFS pin workflows migrated to a typed representation for consistency; end-user status strings and observable behavior remain unchanged.

* **Tests**
  * Test suites and fixtures updated to use the new status representation, ensuring accurate coverage of in-progress, done, error and expired states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->